### PR TITLE
[1.1] Stylesheet update

### DIFF
--- a/v1.1/analysis/odmlTerms.xsl
+++ b/v1.1/analysis/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/analysis/odmlTerms.xsl
+++ b/v1.1/analysis/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/analysis/odmlTerms.xsl
+++ b/v1.1/analysis/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/analysis/odmlTerms.xsl
+++ b/v1.1/analysis/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/analysis/odmlTerms.xsl
+++ b/v1.1/analysis/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/blackrock/odmlTerms.xsl
+++ b/v1.1/blackrock/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/blackrock/odmlTerms.xsl
+++ b/v1.1/blackrock/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/blackrock/odmlTerms.xsl
+++ b/v1.1/blackrock/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/blackrock/odmlTerms.xsl
+++ b/v1.1/blackrock/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/blackrock/odmlTerms.xsl
+++ b/v1.1/blackrock/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/carmenMini/odmlTerms.xsl
+++ b/v1.1/carmenMini/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/carmenMini/odmlTerms.xsl
+++ b/v1.1/carmenMini/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/carmenMini/odmlTerms.xsl
+++ b/v1.1/carmenMini/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/carmenMini/odmlTerms.xsl
+++ b/v1.1/carmenMini/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/carmenMini/odmlTerms.xsl
+++ b/v1.1/carmenMini/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/cell/odmlTerms.xsl
+++ b/v1.1/cell/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/cell/odmlTerms.xsl
+++ b/v1.1/cell/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/cell/odmlTerms.xsl
+++ b/v1.1/cell/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/cell/odmlTerms.xsl
+++ b/v1.1/cell/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/cell/odmlTerms.xsl
+++ b/v1.1/cell/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/collection/odmlTerms.xsl
+++ b/v1.1/collection/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/collection/odmlTerms.xsl
+++ b/v1.1/collection/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/collection/odmlTerms.xsl
+++ b/v1.1/collection/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/collection/odmlTerms.xsl
+++ b/v1.1/collection/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/collection/odmlTerms.xsl
+++ b/v1.1/collection/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/dataset/odmlTerms.xsl
+++ b/v1.1/dataset/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/dataset/odmlTerms.xsl
+++ b/v1.1/dataset/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/dataset/odmlTerms.xsl
+++ b/v1.1/dataset/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/dataset/odmlTerms.xsl
+++ b/v1.1/dataset/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/dataset/odmlTerms.xsl
+++ b/v1.1/dataset/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/electrode/odmlTerms.xsl
+++ b/v1.1/electrode/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/electrode/odmlTerms.xsl
+++ b/v1.1/electrode/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/electrode/odmlTerms.xsl
+++ b/v1.1/electrode/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/electrode/odmlTerms.xsl
+++ b/v1.1/electrode/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/electrode/odmlTerms.xsl
+++ b/v1.1/electrode/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/environment/odmlTerms.xsl
+++ b/v1.1/environment/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/environment/odmlTerms.xsl
+++ b/v1.1/environment/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/environment/odmlTerms.xsl
+++ b/v1.1/environment/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/environment/odmlTerms.xsl
+++ b/v1.1/environment/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/environment/odmlTerms.xsl
+++ b/v1.1/environment/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/event/odmlTerms.xsl
+++ b/v1.1/event/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/event/odmlTerms.xsl
+++ b/v1.1/event/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/event/odmlTerms.xsl
+++ b/v1.1/event/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/event/odmlTerms.xsl
+++ b/v1.1/event/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/event/odmlTerms.xsl
+++ b/v1.1/event/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/experiment/odmlTerms.xsl
+++ b/v1.1/experiment/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/experiment/odmlTerms.xsl
+++ b/v1.1/experiment/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/experiment/odmlTerms.xsl
+++ b/v1.1/experiment/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/experiment/odmlTerms.xsl
+++ b/v1.1/experiment/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/experiment/odmlTerms.xsl
+++ b/v1.1/experiment/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/hardware/odmlTerms.xsl
+++ b/v1.1/hardware/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/hardware/odmlTerms.xsl
+++ b/v1.1/hardware/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/hardware/odmlTerms.xsl
+++ b/v1.1/hardware/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/hardware/odmlTerms.xsl
+++ b/v1.1/hardware/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/hardware/odmlTerms.xsl
+++ b/v1.1/hardware/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/license/odmlTerms.xsl
+++ b/v1.1/license/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/license/odmlTerms.xsl
+++ b/v1.1/license/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/license/odmlTerms.xsl
+++ b/v1.1/license/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/license/odmlTerms.xsl
+++ b/v1.1/license/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/license/odmlTerms.xsl
+++ b/v1.1/license/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/model/odmlTerms.xsl
+++ b/v1.1/model/odmlTerms.xsl
@@ -128,8 +128,6 @@
                <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
             </p>
 
-            <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
             <!--  Check if there are any properties  -->
             <xsl:if test="property">
                <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
                      <th><font size="+1" color="white"><b>Unit</b></font></th>
                      <th><font size="+1" color="white"><b>Type</b></font></th>
                      <th><font size="+1" color="white"><b>Definition</b></font></th>
-                     <th><font size="+1" color="white"><b>Mapping</b></font></th>
                      <th><font size="+1" color="white"><b>Dependency</b></font></th>
                      <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
                   </tr>
@@ -167,14 +164,6 @@
                            </xsl:for-each>
                         </td>
                         <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                        <td width="10%">
-                           <p>
-                              <xsl:for-each select="mapping">
-                                 <xsl:variable name="mapping" select="."/>
-                                 <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                              </xsl:for-each>
-                           </p>
-                        </td>
                         <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                         <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
                      </tr>

--- a/v1.1/model/odmlTerms.xsl
+++ b/v1.1/model/odmlTerms.xsl
@@ -158,11 +158,7 @@
                               <p><xsl:value-of select="unit"/><br/></p>
                            </xsl:for-each>
                         </td>
-                        <td width="5%">
-                           <xsl:for-each select="value">
-                              <p><xsl:value-of select="type"/><br/></p>
-                           </xsl:for-each>
-                        </td>
+                        <td width="5%"><p><xsl:value-of select="type"/></p></td>
                         <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                         <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                         <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/model/odmlTerms.xsl
+++ b/v1.1/model/odmlTerms.xsl
@@ -153,11 +153,7 @@
                               <p><xsl:value-of select="text()"/><br/></p>
                            </xsl:for-each>
                         </td>
-                        <td width="5%">
-                           <xsl:for-each select="value">
-                              <p><xsl:value-of select="unit"/><br/></p>
-                           </xsl:for-each>
-                        </td>
+                        <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                         <td width="5%"><p><xsl:value-of select="type"/></p></td>
                         <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                         <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/model/odmlTerms.xsl
+++ b/v1.1/model/odmlTerms.xsl
@@ -148,11 +148,7 @@
                         <td width="15%"><a name="{$anchor}"/>
                            <p><xsl:value-of select="name"/></p>
                         </td>
-                        <td width="10%">
-                           <xsl:for-each select="value">
-                              <p><xsl:value-of select="text()"/><br/></p>
-                           </xsl:for-each>
-                        </td>
+                        <td width="10%"><p><xsl:value-of select="value"/></p></td>
                         <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                         <td width="5%"><p><xsl:value-of select="type"/></p></td>
                         <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/model/odmlTerms.xsl
+++ b/v1.1/model/odmlTerms.xsl
@@ -131,7 +131,7 @@
             <!--  Check if there are any properties  -->
             <xsl:if test="property">
                <table border="1" rules="rows" width="100%"><font size="-1">
-                  <tr bgcolor="#336699">
+                  <tr bgcolor="#336699" align="left" valign="middle">
                      <th><font size="+1" color="white"><b>Name</b></font></th>
                      <th><font size="+1" color="white"><b>Value</b></font></th>
                      <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/odML.xsd
+++ b/v1.1/odML.xsd
@@ -29,7 +29,6 @@
         <xs:element ref="value" minOccurs="1" maxOccurs="unbounded"/>
         <!-- all other elements are optional -->
         <xs:element name="definition" type="xs:string" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="mapping" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="dependency" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="dependencyValue" type="xs:string" minOccurs="0" maxOccurs="1"/>
       </xs:choice>
@@ -48,7 +47,6 @@
         <xs:element name="link" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="include" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="repository" type="xs:string" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="mapping" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="section" minOccurs="0" maxOccurs="unbounded"/>
       </xs:choice>

--- a/v1.1/odML.xsd
+++ b/v1.1/odML.xsd
@@ -5,29 +5,18 @@
   <!-- THE PROPERTY TYPE IS THE BUILDING BLOCK OF ALL odML METADATA. -->
   <!-- PROPERTIES BASICALLY CONSIST OF name/value PAIRS. -->
   <!-- -->
-  <!-- A: Value Subtype -->
-  <xs:element name ="value" type="xs:string">
-    <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="uncertainty" type="xs:string" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="definition" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="filename" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="encoder" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="checksum" minOccurs="0" maxOccurs="1"/>
-      </xs:choice>
-    </xs:complexType>
-  </xs:element>
-  <!-- B: Property -->
   <xs:element name ="property">
     <xs:complexType>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <!-- if there is a NAME there must also be a VALUE -->
         <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
-        <xs:element ref="value" minOccurs="1" maxOccurs="unbounded"/>
+        <xs:element name="value" minOccurs="1" maxOccurs="unbounded"/>
         <!-- all other elements are optional -->
+        <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="uncertainty" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="value_origin" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="definition" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="dependency" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="dependencyValue" type="xs:string" minOccurs="0" maxOccurs="1"/>

--- a/v1.1/odml.xsl
+++ b/v1.1/odml.xsl
@@ -122,19 +122,19 @@
             <!--  Check if there are any properties  -->
             <xsl:if test="property">
                <table border="1" rules="rows" width="100%"><font size ="-1">
-                  <tr bgcolor="#336699">
+                  <tr bgcolor="#336699" valign="middle" align="left">
                      <th><font size="+1" color="white"><b>Name</b></font></th>
                      <th><font size="+1" color="white"><b>Value</b></font></th>
                      <th><font size="+1" color="white"><b>Uncertainty</b></font></th>
                      <th><font size="+1" color="white"><b>Unit</b></font></th>
-                     <th><font size="+1" color="white"><b>value reference</b></font></th>
                      <th><font size="+1" color="white"><b>Type</b></font></th>
-                     <th><font size="+1" color="white"><b>Comment</b></font></th>
+                     <th><font size="+1" color="white"><b>Reference</b></font></th>
+                     <th><font size="+1" color="white"><b>Definition</b></font></th>
+                     <th><font size="+1" color="white"><b>Value origin</b></font></th>
                      <!--
                        <th><font size="+1" color="white"><b>Dependency</b></font></th>
                        <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
                      -->
-                     <th><font size="+1" color="white"><b>Definition</b></font></th>
                   </tr>
                   <xsl:for-each select="property">
                      <xsl:variable name="anchor">
@@ -145,28 +145,16 @@
                            <p><xsl:value-of select="name"/></p>
                         </td>
                         <td width="10%"><p><xsl:value-of select="value"/></p></td>
-                        <td width="5%">
-                           <xsl:for-each select="value">
-                              <p><xsl:value-of select="uncertainty"/><br/></p>
-                           </xsl:for-each>
-                        </td>
+                        <td width="5%"><p><xsl:value-of select="uncertainty"/></p></td>
                         <td width="5%"><p><xsl:value-of select="unit"/></p></td>
-                        <td width="5%">
-                           <xsl:for-each select="value">
-                              <p><xsl:value-of select="reference"/><br/></p>
-                           </xsl:for-each>
-                        </td>
                         <td width="5%"><p><xsl:value-of select="type"/></p></td>
-                        <td width="22.5%">
-                           <xsl:for-each select="value">
-                              <p><xsl:value-of select="comment"/><br/></p>
-                           </xsl:for-each>
-                        </td>
+                        <td width="5%"><p><xsl:value-of select="reference"/></p></td>
+                        <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
+                        <td width="7.5%%"><p><xsl:value-of select="value_origin"/></p></td>
                         <!--
                           <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                           <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
                         -->
-                        <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                      </tr>
                   </xsl:for-each></font>
                </table>

--- a/v1.1/odml.xsl
+++ b/v1.1/odml.xsl
@@ -117,7 +117,6 @@
                <b>Link: </b><xsl:if test="link"><xsl:value-of select="link"/></xsl:if><br/>
                <b>Include:</b> <xsl:if test="include"><font color="red"><xsl:value-of select="include"/></font></xsl:if><br/>
                <b>Definition:</b> <xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
-               <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
             </p>
 
             <!--  Check if there are any properties  -->

--- a/v1.1/odml.xsl
+++ b/v1.1/odml.xsl
@@ -164,11 +164,7 @@
                               <p><xsl:value-of select="reference"/><br/></p>
                            </xsl:for-each>
                         </td>
-                        <td width="5%">
-                           <xsl:for-each select="value">
-                              <p><xsl:value-of select="type"/><br/></p>
-                           </xsl:for-each>
-                        </td>
+                        <td width="5%"><p><xsl:value-of select="type"/></p></td>
                         <td width="22.5%">
                            <xsl:for-each select="value">
                               <p><xsl:value-of select="comment"/><br/></p>

--- a/v1.1/odml.xsl
+++ b/v1.1/odml.xsl
@@ -144,11 +144,7 @@
                         <td width="15%"><a name="{$anchor}"/>
                            <p><xsl:value-of select="name"/></p>
                         </td>
-                        <td width="10%">
-                           <xsl:for-each select="value">
-                              <p><xsl:value-of select="text()"/><br/></p>
-                           </xsl:for-each>
-                        </td>
+                        <td width="10%"><p><xsl:value-of select="value"/></p></td>
                         <td width="5%">
                            <xsl:for-each select="value">
                               <p><xsl:value-of select="uncertainty"/><br/></p>

--- a/v1.1/odml.xsl
+++ b/v1.1/odml.xsl
@@ -154,11 +154,7 @@
                               <p><xsl:value-of select="uncertainty"/><br/></p>
                            </xsl:for-each>
                         </td>
-                        <td width="5%">
-                           <xsl:for-each select="value">
-                              <p><xsl:value-of select="unit"/><br/></p>
-                           </xsl:for-each>
-                        </td>
+                        <td width="5%"><p><xsl:value-of select="unit"/></p></td>
                         <td width="5%">
                            <xsl:for-each select="value">
                               <p><xsl:value-of select="reference"/><br/></p>

--- a/v1.1/odmlTerms.xsl
+++ b/v1.1/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/odmlTerms.xsl
+++ b/v1.1/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/odmlTerms.xsl
+++ b/v1.1/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/odmlTerms.xsl
+++ b/v1.1/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/odmlTerms.xsl
+++ b/v1.1/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/person/odmlTerms.xsl
+++ b/v1.1/person/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/person/odmlTerms.xsl
+++ b/v1.1/person/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/person/odmlTerms.xsl
+++ b/v1.1/person/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/person/odmlTerms.xsl
+++ b/v1.1/person/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/person/odmlTerms.xsl
+++ b/v1.1/person/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/preparation/odmlTerms.xsl
+++ b/v1.1/preparation/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/preparation/odmlTerms.xsl
+++ b/v1.1/preparation/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/preparation/odmlTerms.xsl
+++ b/v1.1/preparation/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/preparation/odmlTerms.xsl
+++ b/v1.1/preparation/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/preparation/odmlTerms.xsl
+++ b/v1.1/preparation/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/project/odmlTerms.xsl
+++ b/v1.1/project/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/project/odmlTerms.xsl
+++ b/v1.1/project/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/project/odmlTerms.xsl
+++ b/v1.1/project/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/project/odmlTerms.xsl
+++ b/v1.1/project/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/project/odmlTerms.xsl
+++ b/v1.1/project/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/protocol/odmlTerms.xsl
+++ b/v1.1/protocol/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/protocol/odmlTerms.xsl
+++ b/v1.1/protocol/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/protocol/odmlTerms.xsl
+++ b/v1.1/protocol/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/protocol/odmlTerms.xsl
+++ b/v1.1/protocol/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/protocol/odmlTerms.xsl
+++ b/v1.1/protocol/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/questionnaire/odmlTerms.xsl
+++ b/v1.1/questionnaire/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/questionnaire/odmlTerms.xsl
+++ b/v1.1/questionnaire/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/questionnaire/odmlTerms.xsl
+++ b/v1.1/questionnaire/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/questionnaire/odmlTerms.xsl
+++ b/v1.1/questionnaire/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/questionnaire/odmlTerms.xsl
+++ b/v1.1/questionnaire/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/recording/odmlTerms.xsl
+++ b/v1.1/recording/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/recording/odmlTerms.xsl
+++ b/v1.1/recording/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/recording/odmlTerms.xsl
+++ b/v1.1/recording/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/recording/odmlTerms.xsl
+++ b/v1.1/recording/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/recording/odmlTerms.xsl
+++ b/v1.1/recording/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/response/odmlTerms.xsl
+++ b/v1.1/response/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/response/odmlTerms.xsl
+++ b/v1.1/response/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/response/odmlTerms.xsl
+++ b/v1.1/response/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/response/odmlTerms.xsl
+++ b/v1.1/response/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/response/odmlTerms.xsl
+++ b/v1.1/response/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/setup/odmlTerms.xsl
+++ b/v1.1/setup/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/setup/odmlTerms.xsl
+++ b/v1.1/setup/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/setup/odmlTerms.xsl
+++ b/v1.1/setup/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/setup/odmlTerms.xsl
+++ b/v1.1/setup/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/setup/odmlTerms.xsl
+++ b/v1.1/setup/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/software/odmlTerms.xsl
+++ b/v1.1/software/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/software/odmlTerms.xsl
+++ b/v1.1/software/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/software/odmlTerms.xsl
+++ b/v1.1/software/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/software/odmlTerms.xsl
+++ b/v1.1/software/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/software/odmlTerms.xsl
+++ b/v1.1/software/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/stimulus/odmlTerms.xsl
+++ b/v1.1/stimulus/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/stimulus/odmlTerms.xsl
+++ b/v1.1/stimulus/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/stimulus/odmlTerms.xsl
+++ b/v1.1/stimulus/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/stimulus/odmlTerms.xsl
+++ b/v1.1/stimulus/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/stimulus/odmlTerms.xsl
+++ b/v1.1/stimulus/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>

--- a/v1.1/subject/odmlTerms.xsl
+++ b/v1.1/subject/odmlTerms.xsl
@@ -158,11 +158,7 @@
                     <p><xsl:value-of select="unit"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="type"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>

--- a/v1.1/subject/odmlTerms.xsl
+++ b/v1.1/subject/odmlTerms.xsl
@@ -153,11 +153,7 @@
                     <p><xsl:value-of select="text()"/><br/></p>
                   </xsl:for-each>
                 </td>
-                <td width="5%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="unit"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>

--- a/v1.1/subject/odmlTerms.xsl
+++ b/v1.1/subject/odmlTerms.xsl
@@ -148,11 +148,7 @@
                 <td width="15%"><a name="{$anchor}"/>
                   <p><xsl:value-of select="name"/></p>
                 </td>
-                <td width="10%">
-                  <xsl:for-each select="value">
-                    <p><xsl:value-of select="text()"/><br/></p>
-                  </xsl:for-each>
-                </td>
+                <td width="10%"><p><xsl:value-of select="value"/></p></td>
                 <td width="5%"><p><xsl:value-of select="unit"/><br/></p></td>
                 <td width="5%"><p><xsl:value-of select="type"/></p></td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>

--- a/v1.1/subject/odmlTerms.xsl
+++ b/v1.1/subject/odmlTerms.xsl
@@ -128,8 +128,6 @@
           <b>Definition: </b><xsl:if test="definition"><xsl:value-of select="definition"/></xsl:if><br/>
         </p>
 
-        <b>Mapping: </b>   <xsl:if test="mapping"><xsl:value-of select="mapping"/></xsl:if><br/>
-
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
@@ -139,7 +137,6 @@
               <th><font size="+1" color="white"><b>Unit</b></font></th>
               <th><font size="+1" color="white"><b>Type</b></font></th>
               <th><font size="+1" color="white"><b>Definition</b></font></th>
-              <th><font size="+1" color="white"><b>Mapping</b></font></th>
               <th><font size="+1" color="white"><b>Dependency</b></font></th>
               <th><font size="+1" color="white"><b>Dependency Value</b></font></th>
             </tr>
@@ -167,14 +164,6 @@
                   </xsl:for-each>
                 </td>
                 <td width="22.5%"><p><xsl:value-of select="definition"/></p></td>
-                <td width="10%">
-                  <p>
-                    <xsl:for-each select="mapping">
-                      <xsl:variable name="mapping" select="."/>
-                      <p><a href="{$mapping}"><small><xsl:value-of select="."/></small></a></p>
-                    </xsl:for-each>
-                  </p>
-                </td>
                 <td width="5%"><p><xsl:value-of select="dependency"/></p></td>
                 <td width="5%"><p><xsl:value-of select="dependencyValue"/></p></td>
               </tr>

--- a/v1.1/subject/odmlTerms.xsl
+++ b/v1.1/subject/odmlTerms.xsl
@@ -131,7 +131,7 @@
         <!--  Check if there are any properties  -->
         <xsl:if test="property">
           <table border="1" rules="rows" width="100%"><font size="-1">
-            <tr bgcolor="#336699">
+            <tr bgcolor="#336699" align="left" valign="middle">
               <th><font size="+1" color="white"><b>Name</b></font></th>
               <th><font size="+1" color="white"><b>Value</b></font></th>
               <th><font size="+1" color="white"><b>Unit</b></font></th>


### PR DESCRIPTION
This PR updates the stylesheets of branch v1.1 to accommodate the v1.1 format changes:
- removes `Property.mapping` from all `odmlTerms.xsl`.
- updates the usage of `value`, `unit` and `type` in all `odmlTerms.xsl` (closes #7).
- updates `odML.xsd` and `odML.xsl` to odML v1.1 - display was tested with a v1.1 odML data file.
- Add some minor table alignment adjustments for nicer display.
