### PR TITLE
[1.1] Replace 'binary' type with 'text'

### DIFF
--- a/v1.0/questionnaire/questionnaire.xml
+++ b/v1.0/questionnaire/questionnaire.xml
@@ -31,7 +31,7 @@
     <property>
       <name>Question</name>
       <value>
-        <type>question</type>
+        <type>text</type>
       </value>
       <definition>Question of the questionnaire.</definition>
     </property>
@@ -40,7 +40,7 @@
     <property>
       <name>File</name>
       <value>
-        <type>File</type>
+        <type>text</type>
       </value>
       <definition>The binary file with questionnaire.</definition>
     </property>

--- a/v1.1/analysis/analysis.xml
+++ b/v1.1/analysis/analysis.xml
@@ -50,18 +50,8 @@
 
     <property>
       <name>CodeFile</name>
-      <type>text</type>
-      <definition>
-        The program code to analyse the data can be transferred using this property.
-        Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
-        code file.
-      </definition>
-    </property>
-
-    <property>
-      <name>CodeFileURL</name>
       <type>URL</type>
-      <definition>The URL of the applied piece of program code to actually do the analysis.</definition>
+      <definition>The URL to the applied piece of program code performing the analysis.</definition>
     </property>
 
     <property>
@@ -74,59 +64,26 @@
 
     <property>
       <name>ConfigFile</name>
-      <type>text</type>
-      <definition>
-        The configurations used to analyse the data can be transferred using this property.
-        Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
-        configuration file.
-      </definition>
-    </property>
-
-    <property>
-      <name>ConfigFileURL</name>
       <type>URL</type>
-      <definition>The URL of the used configuration file used to run the analysis.</definition>
+      <definition>The URL to the configuration file used to run the analysis.</definition>
     </property>
 
     <property>
       <name>DatasetFile</name>
-      <type>text</type>
-      <definition>
-        The data analysed in the described way can be transferred using this property.
-        Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
-        dataset file.
-      </definition>
-    </property>
-
-    <property>
-      <name>DatasetFileURL</name>
       <type>URL</type>
-      <definition>The URL of a analysed datasetFile.</definition>
+      <definition>The URL to the dataset file the analysis is applied on.</definition>
     </property>
 
     <property>
       <name>ResultFile</name>
-      <type>text</type>
-      <definition>
-        The results of this analysis can be transferred using this property.
-        Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of the results
-        file.
-      </definition>
-    </property>
-
-    <property>
-      <name>ResultFileURL</name>
       <type>URL</type>
-      <definition>The URL of a results file.</definition>
+      <definition>The URL to the results file the analysis was applied on.</definition>
     </property>
 
     <property>
       <name>ResultFigure</name>
-      <type>text</type>
-      <definition>
-        A figure showing the results. This property is meant to store the real figure content.
-        This will blow up the the size of the metadatafile and we recommend to rather define the URL of the figure.
-      </definition>
+      <type>URL</type>
+      <definition>The URL to a figure file showing the results of the analysis.</definition>
     </property>
 
     <property>

--- a/v1.1/analysis/analysis.xml
+++ b/v1.1/analysis/analysis.xml
@@ -50,7 +50,7 @@
 
     <property>
       <name>CodeFile</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>
         The program code to analyse the data can be transferred using this property.
         Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
@@ -74,7 +74,7 @@
 
     <property>
       <name>ConfigFile</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>
         The configurations used to analyse the data can be transferred using this property.
         Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
@@ -90,9 +90,9 @@
 
     <property>
       <name>DatasetFile</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>
-        The data analysed ion the described way can be transferred using this property.
+        The data analysed in the described way can be transferred using this property.
         Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
         dataset file.
       </definition>
@@ -106,7 +106,7 @@
 
     <property>
       <name>ResultFile</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>
         The results of this analysis can be transferred using this property.
         Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of the results
@@ -122,7 +122,7 @@
 
     <property>
       <name>ResultFigure</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>
         A figure showing the results. This property is meant to store the real figure content.
         This will blow up the the size of the metadatafile and we recommend to rather define the URL of the figure.

--- a/v1.1/analysis/power_spectrum.xml
+++ b/v1.1/analysis/power_spectrum.xml
@@ -69,11 +69,8 @@
 
     <property>
       <name>Code</name>
-      <type>text</type>
-      <definition>The program code to analyse the data can be transferred using this property.
-        Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
-        code file.
-      </definition>
+      <type>URL</type>
+      <definition>The URL to the program code file used to perform the data analysis.</definition>
     </property>
 
     <property>
@@ -92,31 +89,20 @@
 
     <property>
       <name>DatasetFile</name>
-      <type>text</type>
-      <definition>
-        The data analysed ion the described way can be transferred using this property.
-        Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
-        dataset file.
-      </definition>
+      <type>URL</type>
+      <definition>The URL to the dataset file the analysis is applied on.</definition>
     </property>
 
     <property>
       <name>ResultFile</name>
-      <type>text</type>
-      <definition>
-        A file containing the results of this analysis. The results of this analysis can be transferred using this
-        property. Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of
-        the results file.
-      </definition>
+      <type>URL</type>
+      <definition>The URL to the results file the analysis was applied on.</definition>
     </property>
 
     <property>
       <name>ResultFigure</name>
-      <type>text</type>
-      <definition>
-        This property is meant to store the real figure content. This will blow up the the size
-        of the metadatafile and we recommend to rather define the URL of the figure.
-      </definition>
+      <type>URL</type>
+      <definition>The URL to a figure file showing the results of the analysis.</definition>
     </property>
 
     <property>

--- a/v1.1/analysis/power_spectrum.xml
+++ b/v1.1/analysis/power_spectrum.xml
@@ -69,7 +69,7 @@
 
     <property>
       <name>Code</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>The program code to analyse the data can be transferred using this property.
         Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
         code file.
@@ -92,7 +92,7 @@
 
     <property>
       <name>DatasetFile</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>
         The data analysed ion the described way can be transferred using this property.
         Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
@@ -102,7 +102,7 @@
 
     <property>
       <name>ResultFile</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>
         A file containing the results of this analysis. The results of this analysis can be transferred using this
         property. Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of
@@ -112,7 +112,7 @@
 
     <property>
       <name>ResultFigure</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>
         This property is meant to store the real figure content. This will blow up the the size
         of the metadatafile and we recommend to rather define the URL of the figure.

--- a/v1.1/analysis/psth.xml
+++ b/v1.1/analysis/psth.xml
@@ -62,15 +62,6 @@
 
     <property>
       <name>CodeFile</name>
-      <type>text</type>
-      <definition>The program code to analyse the data can be transferred using this property.
-        Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
-        code file.
-      </definition>
-    </property>
-
-    <property>
-      <name>CodeFileURL</name>
       <type>URL</type>
       <definition>The URL of the applied piece of program code to actually do the analysis.</definition>
     </property>
@@ -85,55 +76,26 @@
 
     <property>
       <name>ConfigFile</name>
-      <type>text</type>
-      <definition>The configurations used to analyse the data can be transferred using this property.
-        Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
-        configuration file.
-      </definition>
-    </property>
-
-    <property>
-      <name>ConfigFileURL</name>
       <type>URL</type>
-      <definition>The URL of the used configuration file used to run the analysis.</definition>
+      <definition>The URL to the configuration file used to run the analysis.</definition>
     </property>
 
     <property>
       <name>DatasetFile</name>
-      <type>text</type>
-      <definition>The data analysed ion the described way can be transferred using this property.
-        Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
-        dataset file.
-      </definition>
-    </property>
-
-    <property>
-      <name>DatasetFileURL</name>
       <type>URL</type>
-      <definition>The URL of a analysed datasetFile.</definition>
+      <definition>The URL to the dataset file the analysis is applied on.</definition>
     </property>
 
     <property>
       <name>ResultFile</name>
-      <type>text</type>
-      <definition>The results of this analysis can be transferred using this property.
-        Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of the results
-        file.
-      </definition>
-    </property>
-
-    <property>
-      <name>ResultFileURL</name>
       <type>URL</type>
-      <definition>The URL of a results file.</definition>
+      <definition>The URL to the results file the analysis was applied on.</definition>
     </property>
 
     <property>
       <name>ResultFigure</name>
-      <type>text</type>
-      <definition>A figure showing the results. This property is meant to store the real figure content.
-        This will blow up the the size of the metadatafile and we recommend to rather define the URL of the figure.
-      </definition>
+      <type>URL</type>
+      <definition>The URL to a figure file showing the results of the analysis.</definition>
     </property>
 
     <property>

--- a/v1.1/analysis/psth.xml
+++ b/v1.1/analysis/psth.xml
@@ -62,7 +62,7 @@
 
     <property>
       <name>CodeFile</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>The program code to analyse the data can be transferred using this property.
         Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
         code file.
@@ -85,7 +85,7 @@
 
     <property>
       <name>ConfigFile</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>The configurations used to analyse the data can be transferred using this property.
         Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
         configuration file.
@@ -100,7 +100,7 @@
 
     <property>
       <name>DatasetFile</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>The data analysed ion the described way can be transferred using this property.
         Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of underlying
         dataset file.
@@ -115,7 +115,7 @@
 
     <property>
       <name>ResultFile</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>The results of this analysis can be transferred using this property.
         Using it will blow up the the size of the metadatafile and we recommend to rather define the URL of the results
         file.
@@ -130,10 +130,10 @@
 
     <property>
       <name>ResultFigure</name>
+      <type>text</type>
       <definition>A figure showing the results. This property is meant to store the real figure content.
         This will blow up the the size of the metadatafile and we recommend to rather define the URL of the figure.
       </definition>
-      <type>binary</type>
     </property>
 
     <property>

--- a/v1.1/dataset/dataset.xml
+++ b/v1.1/dataset/dataset.xml
@@ -61,7 +61,7 @@
 
     <property>
       <name>File</name>
-      <type>binary</type>
+      <type>text</type>
       <definition>Data of this dataset. Be aware that including the actual content of a data file by this property
         will blow up the the size of the metadatafile. We rather recommend to simply refer to the URL of a dataset
         file using the FileURL property.

--- a/v1.1/dataset/dataset.xml
+++ b/v1.1/dataset/dataset.xml
@@ -61,11 +61,8 @@
 
     <property>
       <name>File</name>
-      <type>text</type>
-      <definition>Data of this dataset. Be aware that including the actual content of a data file by this property
-        will blow up the the size of the metadatafile. We rather recommend to simply refer to the URL of a dataset
-        file using the FileURL property.
-      </definition>
+      <type>URL</type>
+      <definition>The URL to the file containing the data of this dataset.</definition>
     </property>
 
     <property>

--- a/v1.1/protocol/protocol.xml
+++ b/v1.1/protocol/protocol.xml
@@ -32,12 +32,6 @@
 
     <property>
       <name>ProtocolFile</name>
-      <definition>Protocol File</definition>
-      <type>text</type>
-    </property>
-
-    <property>
-      <name>ProtocolFileURL</name>
       <definition>URL for protocol file</definition>
       <type>URL</type>
     </property>

--- a/v1.1/protocol/protocol.xml
+++ b/v1.1/protocol/protocol.xml
@@ -33,7 +33,7 @@
     <property>
       <name>ProtocolFile</name>
       <definition>Protocol File</definition>
-      <type>binary</type>
+      <type>text</type>
     </property>
 
     <property>

--- a/v1.1/questionnaire/questionnaire.xml
+++ b/v1.1/questionnaire/questionnaire.xml
@@ -27,13 +27,13 @@
     <property>
       <name>Question</name>
       <definition>Question of the questionnaire.</definition>
-      <type>question</type>
+      <type>text</type>
     </property>
 
     <property>
       <name>File</name>
       <definition>The binary file with questionnaire.</definition>
-      <type>File</type>
+      <type>text</type>
     </property>
 
     <property>

--- a/v1.1/response/response.xml
+++ b/v1.1/response/response.xml
@@ -82,17 +82,7 @@
 
     <property>
       <name>ResponseFile</name>
-      <definition>The response file received. Using it will blow up the the size of the metadatafile and we recommend to
-        rather define the URL of underlying response file.
-      </definition>
-      <type>text</type>
-    </property>
-
-    <property>
-      <name>ResponseFileURL</name>
-      <definition>The URL of a an received response file. This is the recommended alternative to explicitly including
-        the actual response via ResponseFile.
-      </definition>
+      <definition>The URL to a received response file.</definition>
       <type>URL</type>
     </property>
 

--- a/v1.1/response/response.xml
+++ b/v1.1/response/response.xml
@@ -85,7 +85,7 @@
       <definition>The response file received. Using it will blow up the the size of the metadatafile and we recommend to
         rather define the URL of underlying response file.
       </definition>
-      <type>binary</type>
+      <type>text</type>
     </property>
 
     <property>

--- a/v1.1/stimulus/stimulus.xml
+++ b/v1.1/stimulus/stimulus.xml
@@ -84,17 +84,7 @@
 
     <property>
       <name>StimulusFile</name>
-      <definition>The stimulus file used. Using it will blow up the the size of the metadatafile and we recommend to
-        rather define the URL of underlying stimulus file.
-      </definition>
-      <type>text</type>
-    </property>
-
-    <property>
-      <name>StimulusFileURL</name>
-      <definition>The URL of a an applied stimulus file. This is the recommended alternative to explicitely including
-        the actual stimulus via StimulusFile.
-      </definition>
+      <definition>The URL to an applied stimulus file.</definition>
       <type>URL</type>
     </property>
 

--- a/v1.1/stimulus/stimulus.xml
+++ b/v1.1/stimulus/stimulus.xml
@@ -87,7 +87,7 @@
       <definition>The stimulus file used. Using it will blow up the the size of the metadatafile and we recommend to
         rather define the URL of underlying stimulus file.
       </definition>
-      <type>binary</type>
+      <type>text</type>
     </property>
 
     <property>


### PR DESCRIPTION
This PR refactors all property entries with the `binary` dtype, since this dtype is no longer available in odml 1.4. From this point on storing the actual binary data in an odml file is not encouraged and only a URL to the corresponding files should be provided.

The concerned properties containing `binary` dtype were refactored as follows:
- Where an identical property with the same name and the extension and dtype `URL` was present, the `binary` property was removed, the `[name]URL` property was renamed to `[name]` and the `definition` was adapted appropriately.
- Otherwise just the dtype of the concerned property was changed to dtype `URL` and the `definition` adapted if required.

Loading of all files were successfully tested via a local server.

Closes #10.
