### PR TITLE
Complete datacite rewrite

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
         <div class="wrapper">
             <sec>
-                <p><img src="https://terminologies.g-node.org/images/odMLLogo.png" /></p>
+                <p><img src="https://terminologies.g-node.org/images/odMLTitle.png" /></p>
                 <p>
                     odML (open metadata Markup Language) is a file format for storing
                     arbitrary metadata. The underlying data model offers a way to store

--- a/index.html
+++ b/index.html
@@ -33,15 +33,19 @@
                     the linked terminology. This page hosts all currently available odML Terminology files.
                 </p>
 
+                <h2 id="version_latest">Current version</h2>
                 <p>
                     The following leads to the latest version (v1.1) of the
                     <a href="https://terminologies.g-node.org/v1.1/terminologies.xml">odML Terminologies</a>.
                 </p>
+
+                <h2 id="version_1.0">Previous versions</h2>
                 <p>
                     Previous odML Terminology versions can be found <a href="https://terminologies.g-node.org/v1.0/index.xml">here</a>
                     which contain all available odML Terminology files in the odML format version v1.0.
                 </p>
 
+                <h2 id="involvement">Get involved</h2>
                 <p>
                     The Terminologies are a community project, if you find something missing,
                     please consider adding your comments, issues or even terminology files

--- a/v1.1/datareference/datacite.xml
+++ b/v1.1/datareference/datacite.xml
@@ -455,6 +455,11 @@
                 <definition>Any rights information for this resource. The property may be repeated to record complex rights characteristics.</definition>
 
                 <property>
+                    <name>rights</name>
+                    <type>string</type>
+                    <definition>Value of rights.</definition>
+                </property>
+                <property>
                     <name>rightsURI</name>
                     <type>url</type>
                     <definition>The URI of the license.</definition>

--- a/v1.1/datareference/datacite.xml
+++ b/v1.1/datareference/datacite.xml
@@ -7,13 +7,13 @@
 
     <section>
         <name>DataCite</name>
-        <type>DataReference</type>
+        <type>data_reference</type>
         <definition>A published dataset referenced by a DOI and registered with DataCite. The referenced dataset will contain either the odML file itself or the data the odML is annotating.</definition>
 
         <!-- #1 identifier -->
         <section>
             <name>identifier</name>
-            <type>DataCite/identifier</type>
+            <type>datacite/identifier</type>
             <definition>The Identifier is a unique string that identifies a resource.  For software, determine whether the identifier is for a specific version of a piece of software, (per the Force11 Software Citation Principles11), or for all versions.</definition>
 
             <property>
@@ -32,11 +32,11 @@
         <!-- #2 creators -->
         <section>
             <name>creators</name>
-            <type>DataCite/creator</type>
+            <type>datacite/creators</type>
 
             <section>
                 <name>creator #</name>
-                <type>DataCite/creator</type>
+                <type>datacite/creators/creator</type>
                 <definition>The main researchers involved in producing the data, or the authors of the publication, in priority order. To supply multiple creators, repeat this property.</definition>
 
                 <property>
@@ -63,7 +63,7 @@
 
                 <section>
                     <name>namedIdentifier #</name>
-                    <type>DataCite/creator</type>
+                    <type>datacite/creators/creator/named_identifier</type>
                     <definition>Uniquely identifies an individual or legal entity, according to various schemes.</definition>
 
                     <property>
@@ -85,7 +85,7 @@
 
                 <section>
                     <name>affiliation #</name>
-                    <type>DataCite/creator</type>
+                    <type>datacite/creators/creator/affiliation</type>
                     <definition>The organizational or institutional affiliation of the creator.</definition>
 
                     <property>
@@ -115,11 +115,11 @@
         <!-- #3 Title -->
         <section>
             <name>titles</name>
-            <type>DataCite/title</type>
+            <type>datacite/titles</type>
 
             <section>
                 <name>title #</name>
-                <type>DataCite/title</type>
+                <type>datacite/titles/title</type>
                 <definition>A name or title by which a resource is known. May be the title of a dataset or the name of a piece of software.</definition>
 
                 <property>
@@ -153,7 +153,7 @@
         <!-- #10 ResourceType -->
         <section>
             <name>resourceType</name>
-            <type>DataCite/resourceType</type>
+            <type>datacite/resource_type</type>
             <definition>A description of the resource. The format is open, but the preferred format is a single term of some detail so that a pair can be formed with the sub-property. Text formats can be free-text OR terms from the CASRAI Publications resource type list.</definition>
 
             <property>
@@ -173,11 +173,11 @@
         <!-- can be used to provide keywords describing the dataset -->
         <section>
             <name>subjects</name>
-            <type>DataCite/subject</type>
+            <type>datacite/subjects</type>
 
             <section>
                 <name>subject #</name>
-                <type>DataCite/subject</type>
+                <type>datacite/subjects/subject</type>
                 <definition>Subject, keyword, classification code, or key phrase describing the resource.</definition>
 
                 <property>
@@ -206,11 +206,11 @@
         <!-- #7 Contributor -->
         <section>
             <name>contributors</name>
-            <type>DataCite/contributor</type>
+            <type>datacite/contributors</type>
 
             <section>
                 <name>contributor #</name>
-                <type>DataCite/contributor</type>
+                <type>datacite/contributors/contributor</type>
                 <definition>The institution or person responsible for collecting, managing, distributing, or otherwise contributing to the development of the resource.To supply multiple contributors, repeat this property.For software, if there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "hostingInstitution" for the code repository.</definition>
 
                 <property>
@@ -243,7 +243,7 @@
 
                 <section>
                     <name>namedIdentifier #</name>
-                    <type>DataCite/contributor</type>
+                    <type>datacite/contributors/contributor/named_identifier</type>
                     <definition>Uniquely identifies an individual or legal entity, according to various schemes.</definition>
 
                     <property>
@@ -265,7 +265,7 @@
 
                 <section>
                     <name>affiliation #</name>
-                    <type>DataCite/contributor</type>
+                    <type>datacite/contributors/contributor/affiliation</type>
                     <definition>The organizational or institutional affiliation of the contributor.</definition>
 
                     <property>
@@ -295,11 +295,11 @@
         <!-- #8 date -->
         <section>
             <name>dates</name>
-            <type>DataCite/date</type>
+            <type>datacite/dates</type>
 
             <section>
                 <name>date #</name>
-                <type>DataCite/date</type>
+                <type>datacite/dates/date</type>
                 <definition>Different dates relevant to the work.</definition>
 
                 <property>
@@ -331,11 +331,11 @@
         <!-- #11 alternateIdentifier  -->
         <section>
             <name>alternateIdentifiers</name>
-            <type>DataCite/alternateIdentifier</type>
+            <type>datacite/alternateIdentifiers</type>
 
             <section>
                 <name>alternateIdentifier #</name>
-                <type>DataCite/alternateIdentifier</type>
+                <type>datacite/alternateIdentifiers/alternateIdentifier</type>
                 <definition>An identifier or identifiers other than the primary Identifier applied to the resource being registered. This may be any alphanumeric string which is unique within its domain of issue. May be used for local identifiers. AlternateIdentifier should be used for another identifier of the same instance (same location, same file).</definition>
 
                 <property>
@@ -354,11 +354,11 @@
         <!-- #12 relatedIdentifier -->
         <section>
             <name>relatedIdentifiers</name>
-            <type>DataCite/relatedIdentifier</type>
+            <type>datacite/related_identifiers</type>
 
             <section>
                 <name>relatedIdentifier #</name>
-                <type>DataCite/relatedIdentifier</type>
+                <type>datacite/related_identifiers/related_identifier</type>
                 <definition>Identifiers of related resources. These must be globally unique identifiers.</definition>
 
                 <property>
@@ -404,11 +404,11 @@
         <!-- #13 size -->
         <section>
             <name>sizes</name>
-            <type>DataCite/size</type>
+            <type>datacite/sizes</type>
 
             <section>
                 <name>size #</name>
-                <type>DataCite/size</type>
+                <type>datacite/sizes/size</type>
                 <definition>Size (e.g. bytes, pages, inches, etc.) or duration (extent), e.g. hours, minutes, days, etc., of a resource.</definition>
 
                 <property>
@@ -422,11 +422,11 @@
         <!-- #14 format -->
         <section>
             <name>formats</name>
-            <type>DataCite/format</type>
+            <type>datacite/formats</type>
 
             <section>
                 <name>format #</name>
-                <type>DataCite/format</type>
+                <type>datacite/formats/format</type>
                 <definition>Technical format of the resource.</definition>
 
                 <property>
@@ -447,11 +447,11 @@
         <!-- #16 Rights -->
         <section>
             <name>rightsList</name>
-            <type>DataCite/rights</type>
+            <type>datacite/rights_list</type>
 
             <section>
                 <name>rights #</name>
-                <type>DataCite/rights</type>
+                <type>datacite/rights_list/rights</type>
                 <definition>Any rights information for this resource. The property may be repeated to record complex rights characteristics.</definition>
 
                 <property>
@@ -485,11 +485,11 @@
         <!-- #17 description -->
         <section>
             <name>descriptions</name>
-            <type>DataCite/description</type>
+            <type>datacite/descriptions</type>
 
             <section>
                 <name>description #</name>
-                <type>DataCite/description</type>
+                <type>datacite/descriptions/description</type>
                 <definition>All additional information that does not fit in any of the other categories. May be used for technical information.</definition>
 
                 <property>
@@ -509,11 +509,11 @@
         <!-- #18 geolocation -->
         <section>
             <name>geoLocations</name>
-            <type>DataCite/geoLocation</type>
+            <type>datacite/geo_locations</type>
 
             <section>
                 <name>geoLocation #</name>
-                <type>DataCite/geoLocation</type>
+                <type>datacite/geo_locations/geo_location</type>
                 <definition>Spatial region or named place where the data was gathered or about which the data is focused.</definition>
 
                 <property>
@@ -524,7 +524,7 @@
 
                 <section>
                     <name>geoLocationPoint</name>
-                    <type>DataCite/geoLocation</type>
+                    <type>datacite/geo_locations/geo_location/geo_location_point</type>
                     <definition>A point location in space.</definition>
 
                     <property>
@@ -540,7 +540,7 @@
                 </section>
                 <section>
                     <name>geoLocationBox</name>
-                    <type>DataCite/geoLocation</type>
+                    <type>datacite/geo_locations/geo_location/geo_location_box</type>
                     <definition>The spatial limits of a box. A box is defined by two geographic points. Left low corner and right upper corner. Each point is defined by its longitude and latitude.</definition>
 
                     <property>
@@ -566,12 +566,12 @@
                 </section>
                 <section>
                     <name>geoLocationPolygon</name>
-                    <type>DataCite/geoLocation</type>
+                    <type>datacite/geo_locations/geo_location/geo_location_polygon</type>
                     <definition>A drawn polygon area, defined by a set of points and lines connecting the points in a closed chain.</definition>
 
                     <section>
                         <name>polygonPoint #</name>
-                        <type>DataCite</type>
+                        <type>datacite/geo_locations/geo_location/geo_location_polygon/polygon_point</type>
                         <definition>A point location in a polygon. If geoLocationPolygon is used, polygonPoint must be used as well. There must be at least 4 non-aligned points to make a closed curve, with the last point described the same as the first point.</definition>
 
                         <property>
@@ -592,11 +592,11 @@
         <!-- #19 fundingReference -->
         <section>
             <name>fundingReferences</name>
-            <type>DataCite/fundingReference</type>
+            <type>datacite/funding_references</type>
 
             <section>
                 <name>fundingReference #</name>
-                <type>DataCite/fundingReference</type>
+                <type>datacite/funding_references/funding_reference</type>
                 <definition>Information about financial support (funding) for the resource being registered.</definition>
 
                 <property>
@@ -642,12 +642,12 @@
 
     <section>
         <name>DataCiteComplement</name>
-        <type>DataReference</type>
+        <type>data_reference</type>
         <definition>Additional sections complementing the Datacite scheme. The information contained in this section is not supported by the DataCite scheme.</definition>
 
         <section>
             <name>version</name>
-            <type>DataCiteComplement/version</type>
+            <type>datacite_complement/version</type>
             <definition>The implemented datacite schema version</definition>
 
             <property>
@@ -660,11 +660,11 @@
 
         <section>
             <name>references</name>
-            <type>DataCiteComplement/reference</type>
+            <type>datacite_complement/references</type>
 
             <section>
                 <name>reference #</name>
-                <type>DataCiteComplement/reference</type>
+                <type>datacite_complement/references/reference</type>
                 <definition>A publication the published dataset is referencing.</definition>
 
                 <property>

--- a/v1.1/datareference/datacite.xml
+++ b/v1.1/datareference/datacite.xml
@@ -205,7 +205,7 @@
 
         <!-- #7 Contributor -->
         <section>
-            <name>contributrors</name>
+            <name>contributors</name>
             <type>DataCite</type>
 
             <section>
@@ -214,7 +214,7 @@
                 <definition>The institution or person responsible for collecting, managing, distributing, or otherwise contributing to the development of the resource.To supply multiple contributors, repeat this property.For software, if there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "hostingInstitution" for the code repository.</definition>
 
                 <property>
-                    <name>contributerType</name>
+                    <name>contributorType</name>
                     <type>string</type>
                     <value>[ContactPerson, DataCollector, DataCurator, DataManager, Distributor, Editor, HostingInstitution, Producer, ProjectLeader, ProjectManager, ProjectMember, RegistrationAgency, RegistrationAuthority, RelatedPerson, Researcher, ResearchGroup, RightsHolder, Sponsor, Supervisor, WorkPackageLeader, Other]</value>
                     <definition>The type of contributor of the resource.</definition>
@@ -673,7 +673,7 @@
                     <definition>refType might be: IsCitedBy, IsSupplementTo, IsReferencedBy, IsPartOf for further valid types see https://schema.datacite.org/meta/kernel-4</definition>
                 </property>
                 <property>
-                    <name>PublictionCitation</name>
+                    <name>PublicationCitation</name>
                     <type>string</type>
                     <definition>Full citation of the reference publication</definition>
                 </property>

--- a/v1.1/datareference/datacite.xml
+++ b/v1.1/datareference/datacite.xml
@@ -36,7 +36,7 @@
 
             <section>
                 <name>creator #</name>
-                <type>datacite/creators/creator</type>
+                <type>datacite/creator</type>
                 <definition>The main researchers involved in producing the data, or the authors of the publication, in priority order. To supply multiple creators, repeat this property.</definition>
 
                 <property>
@@ -63,7 +63,7 @@
 
                 <section>
                     <name>namedIdentifier #</name>
-                    <type>datacite/creators/creator/named_identifier</type>
+                    <type>datacite/creator/named_identifier</type>
                     <definition>Uniquely identifies an individual or legal entity, according to various schemes.</definition>
 
                     <property>
@@ -85,7 +85,7 @@
 
                 <section>
                     <name>affiliation #</name>
-                    <type>datacite/creators/creator/affiliation</type>
+                    <type>datacite/creator/affiliation</type>
                     <definition>The organizational or institutional affiliation of the creator.</definition>
 
                     <property>
@@ -119,7 +119,7 @@
 
             <section>
                 <name>title #</name>
-                <type>datacite/titles/title</type>
+                <type>datacite/title</type>
                 <definition>A name or title by which a resource is known. May be the title of a dataset or the name of a piece of software.</definition>
 
                 <property>
@@ -177,7 +177,7 @@
 
             <section>
                 <name>subject #</name>
-                <type>datacite/subjects/subject</type>
+                <type>datacite/subject</type>
                 <definition>Subject, keyword, classification code, or key phrase describing the resource.</definition>
 
                 <property>
@@ -210,7 +210,7 @@
 
             <section>
                 <name>contributor #</name>
-                <type>datacite/contributors/contributor</type>
+                <type>datacite/contributor</type>
                 <definition>The institution or person responsible for collecting, managing, distributing, or otherwise contributing to the development of the resource.To supply multiple contributors, repeat this property.For software, if there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "hostingInstitution" for the code repository.</definition>
 
                 <property>
@@ -243,7 +243,7 @@
 
                 <section>
                     <name>namedIdentifier #</name>
-                    <type>datacite/contributors/contributor/named_identifier</type>
+                    <type>datacite/contributor/named_identifier</type>
                     <definition>Uniquely identifies an individual or legal entity, according to various schemes.</definition>
 
                     <property>
@@ -265,7 +265,7 @@
 
                 <section>
                     <name>affiliation #</name>
-                    <type>datacite/contributors/contributor/affiliation</type>
+                    <type>datacite/contributor/affiliation</type>
                     <definition>The organizational or institutional affiliation of the contributor.</definition>
 
                     <property>
@@ -299,7 +299,7 @@
 
             <section>
                 <name>date #</name>
-                <type>datacite/dates/date</type>
+                <type>datacite/date</type>
                 <definition>Different dates relevant to the work.</definition>
 
                 <property>
@@ -335,7 +335,7 @@
 
             <section>
                 <name>alternateIdentifier #</name>
-                <type>datacite/alternate_identifiers/alternate_identifier</type>
+                <type>datacite/alternate_identifier</type>
                 <definition>An identifier or identifiers other than the primary Identifier applied to the resource being registered. This may be any alphanumeric string which is unique within its domain of issue. May be used for local identifiers. AlternateIdentifier should be used for another identifier of the same instance (same location, same file).</definition>
 
                 <property>
@@ -358,7 +358,7 @@
 
             <section>
                 <name>relatedIdentifier #</name>
-                <type>datacite/related_identifiers/related_identifier</type>
+                <type>datacite/related_identifier</type>
                 <definition>Identifiers of related resources. These must be globally unique identifiers.</definition>
 
                 <property>
@@ -408,7 +408,7 @@
 
             <section>
                 <name>size #</name>
-                <type>datacite/sizes/size</type>
+                <type>datacite/size</type>
                 <definition>Size (e.g. bytes, pages, inches, etc.) or duration (extent), e.g. hours, minutes, days, etc., of a resource.</definition>
 
                 <property>
@@ -426,7 +426,7 @@
 
             <section>
                 <name>format #</name>
-                <type>datacite/formats/format</type>
+                <type>datacite/format</type>
                 <definition>Technical format of the resource.</definition>
 
                 <property>
@@ -451,7 +451,7 @@
 
             <section>
                 <name>rights #</name>
-                <type>datacite/rights_list/rights</type>
+                <type>datacite/rights</type>
                 <definition>Any rights information for this resource. The property may be repeated to record complex rights characteristics.</definition>
 
                 <property>
@@ -489,7 +489,7 @@
 
             <section>
                 <name>description #</name>
-                <type>datacite/descriptions/description</type>
+                <type>datacite/description</type>
                 <definition>All additional information that does not fit in any of the other categories. May be used for technical information.</definition>
 
                 <property>
@@ -513,7 +513,7 @@
 
             <section>
                 <name>geoLocation #</name>
-                <type>datacite/geo_locations/geo_location</type>
+                <type>datacite/geo_location</type>
                 <definition>Spatial region or named place where the data was gathered or about which the data is focused.</definition>
 
                 <property>
@@ -524,7 +524,7 @@
 
                 <section>
                     <name>geoLocationPoint</name>
-                    <type>datacite/geo_locations/geo_location/geo_location_point</type>
+                    <type>datacite/geo_location/geo_location_point</type>
                     <definition>A point location in space.</definition>
 
                     <property>
@@ -540,7 +540,7 @@
                 </section>
                 <section>
                     <name>geoLocationBox</name>
-                    <type>datacite/geo_locations/geo_location/geo_location_box</type>
+                    <type>datacite/geo_location/geo_location_box</type>
                     <definition>The spatial limits of a box. A box is defined by two geographic points. Left low corner and right upper corner. Each point is defined by its longitude and latitude.</definition>
 
                     <property>
@@ -566,12 +566,12 @@
                 </section>
                 <section>
                     <name>geoLocationPolygon</name>
-                    <type>datacite/geo_locations/geo_location/geo_location_polygon</type>
+                    <type>datacite/geo_location/geo_location_polygon</type>
                     <definition>A drawn polygon area, defined by a set of points and lines connecting the points in a closed chain.</definition>
 
                     <section>
                         <name>polygonPoint #</name>
-                        <type>datacite/geo_locations/geo_location/geo_location_polygon/polygon_point</type>
+                        <type>datacite/geo_location/geo_location_polygon/polygon_point</type>
                         <definition>A point location in a polygon. If geoLocationPolygon is used, polygonPoint must be used as well. There must be at least 4 non-aligned points to make a closed curve, with the last point described the same as the first point.</definition>
 
                         <property>
@@ -596,7 +596,7 @@
 
             <section>
                 <name>fundingReference #</name>
-                <type>datacite/funding_references/funding_reference</type>
+                <type>datacite/funding_reference</type>
                 <definition>Information about financial support (funding) for the resource being registered.</definition>
 
                 <property>
@@ -664,7 +664,7 @@
 
             <section>
                 <name>reference #</name>
-                <type>datacite_complement/references/reference</type>
+                <type>datacite_complement/reference</type>
                 <definition>A publication the published dataset is referencing.</definition>
 
                 <property>

--- a/v1.1/datareference/datacite.xml
+++ b/v1.1/datareference/datacite.xml
@@ -45,7 +45,7 @@
                     <definition>The full name of the creator.</definition>
                 </property>
                 <property>
-                    <name>creatorNameType</name>
+                    <name>nameType</name>
                     <type>string</type>
                     <value>[Organizational, Personal (default)]</value>
                     <definition>The type of name</definition>

--- a/v1.1/datareference/datacite.xml
+++ b/v1.1/datareference/datacite.xml
@@ -2,82 +2,683 @@
 <?xml-stylesheet type="text/xsl" href="https://terminologies.g-node.org/_resources/odmlDocument.xsl" xmlns:odml="http://www.g-node.org/odml"?>
 <odML version="1.1">
     <repository>https://terminologies.g-node.org/v1.1/terminologies.xml</repository>
-    <version>1.0</version>
-    <date>2019-03-26</date>
-    <!-- *********************************************************        -->
-    <!--                      Data reference section                      -->
-    <!--  The minimal description of a data reference is a URI linking back
-          to the repository the odml file or the data the odml document describes
-          resides in.
-          Further details common to the different types of data reference sections
-          can be added via the reference description section              -->
-    <!-- *********************************************************        -->
+    <version>1.1</version>
+    <date>2019-10-15</date>
+
     <section>
-        <type>DataReference</type>
         <name>DataCite</name>
-        <definition>A published dataset referenced by a DOI and registered with DataCite. The referenced dataset will contain either the odML file itself or the data the odML is annotating.
-        </definition>
+        <type>DataReference</type>
+        <definition>A published dataset referenced by a DOI and registered with DataCite. The referenced dataset will contain either the odML file itself or the data the odML is annotating.</definition>
 
-        <property>
-            <name>DataDOI</name>
-            <definition>A unique Digital object identifier of data. In the current context a URI linking to the published dataset.</definition>
-            <type>url</type>
-        </property>
-
-        <property>
-            <name>ResourceType</name>
-            <definition>A description of the resource. The format is open, but the preferred format is a single term of some detail so that a pair can be formed with the sub-property.Text formats can be free-text OR terms from the CASRAI Publications resource type list. In the odML context the value will mostly be 'Dataset'.</definition>
-            <type>string</type>
-        </property>
-
+        <!-- #1 identifier -->
         <section>
-            <type>DataReference</type>
-            <name>DataCiteReference</name>
-            <definition>A publication the published dataset is referencing.</definition>
+            <name>identifier</name>
+            <type>DataCite</type>
+            <definition>The Identifier is a unique string that identifies a resource.  For software, determine whether the identifier is for a specific version of a piece of software, (per the Force11 Software Citation Principles11), or for all versions.</definition>
+
             <property>
-                <name>DOI</name>
-                <definition>DOI to the referenced publication</definition>
+                <name>identifierType</name>
                 <type>string</type>
+                <value>DOI</value>
+                <definition>The type of Identifier.</definition>
             </property>
             <property>
-                <name>RefType</name>
-                <definition>refType might be: IsCitedBy, IsSupplementTo, IsReferencedBy, IsPartOf for further valid types see https://schema.datacite.org/meta/kernel-4</definition>
+                <name>identifier</name>
                 <type>string</type>
-            </property>
-            <property>
-                <name>PublicationCitation</name>
-                <definition>Full citation of the reference publication</definition>
-                <type>string</type>
+                <definition>The value of the identifier.</definition>
             </property>
         </section>
 
+        <!-- #2 creators -->
         <section>
-            <type>DataReference</type>
-            <name>DataCiteAuthor</name>
-            <definition>Information about an author as required by DataCite.</definition>
-            <property>
-                <name>FirstName</name>
-                <definition>The authors first Name (John).</definition>
-                <type>string</type>
-            </property>
+            <name>creators</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>creator #</name>
+                <type>DataCite</type>
+                <definition>The main researchers involved in producing the data, or the authors of the publication, in priority order. To supply multiple creators, repeat this property.</definition>
+
+                <property>
+                    <name>creatorName</name>
+                    <type>string</type>
+                    <definition>The full name of the creator.</definition>
+                </property>
+                <property>
+                    <name>creatorNameType</name>
+                    <type>string</type>
+                    <value>[Organizational, Personal (default)]</value>
+                    <definition>The type of name</definition>
+                </property>
+                <property>
+                    <name>givenName</name>
+                    <type>string</type>
+                    <definition>The personal or first name of the creator.</definition>
+                </property>
+                <property>
+                    <name>familyName</name>
+                    <type>string</type>
+                    <definition>The surname or last name of the creator.</definition>
+                </property>
+
+                <section>
+                    <name>namedIdentifier #</name>
+                    <type>DataCite</type>
+                    <definition>Uniquely identifies an individual or legal entity, according to various schemes.</definition>
+
+                    <property>
+                        <name>namedIdentifier</name>
+                        <type>string</type>
+                        <definition>Value of the named identifier</definition>
+                    </property>
+                    <property>
+                        <name>nameIdentifierScheme</name>
+                        <type>string</type>
+                        <definition>The name of the name identifier scheme. Examples: ORCID, ISNI, ROR, GRID</definition>
+                    </property>
+                    <property>
+                        <name>schemeURI</name>
+                        <type>url</type>
+                        <definition>The URI of the name identifier scheme.</definition>
+                    </property>
+                </section>
+
+                <section>
+                    <name>affiliation #</name>
+                    <type>DataCite</type>
+                    <definition>The organizational or institutional affiliation of the creator.</definition>
+
+                    <property>
+                        <name>affiliation</name>
+                        <type>string</type>
+                        <definition>Value of the affiliation</definition>
+                    </property>
+                    <property>
+                        <name>affiliationIdentifier</name>
+                        <type>string</type>
+                        <definition>Uniquely identifies the organizational affiliation of the creator.</definition>
+                    </property>
+                    <property>
+                        <name>affiliationIdentifierScheme</name>
+                        <type>string</type>
+                        <definition>Name of the affiliation identifier schema. Examples: ROR, GRID</definition>
+                    </property>
+                    <property>
+                        <name>schemeURI</name>
+                        <type>url</type>
+                        <definition>URI of the affiliation identifier schema.</definition>
+                    </property>
+                </section>
+            </section>
+        </section>
+
+        <!-- #3 Title -->
+        <section>
+            <name>titles</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>title #</name>
+                <type>DataCite</type>
+                <definition>A name or title by which a resource is known. May be the title of a dataset or the name of a piece of software.</definition>
+
+                <property>
+                    <name>title</name>
+                    <type>string</type>
+                    <definition>Value of title</definition>
+                </property>
+                <property>
+                    <name>titleType</name>
+                    <type>string</type>
+                    <value>[AlternativeTitle, Subtitle, TranslatedTitle, Other]</value>
+                    <definition>The type of Title.</definition>
+                </property>
+            </section>
+        </section>
+
+        <!-- #4 Publisher -->
+        <property>
+            <name>publisher</name>
+            <type>string</type>
+            <definition>The name of the entity that holds, archives, publishes prints, distributes, releases, issues, or produces the resource. This property will be used to formulate the citation, so consider the prominence of the role. For software, use Publisher for the code repository. If there is an entity other than a code repository, that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the property Contributor/contributorType/hostingInstitution for the code repository.</definition>
+        </property>
+
+        <!-- #5 PublicationYear -->
+        <property>
+            <name>publicationYear</name>
+            <type>string</type>
+            <definition>The year when the data was or will be made publicly available.  In the case of resources such as software or dynamic data where there may be multiple releases in one year, include the Date/dateType/dateInformation property and sub-properties to provide more information about the publication or release date details.</definition>
+        </property>
+
+        <!-- #10 ResourceType -->
+        <section>
+            <name>resourceType</name>
+            <type>DataCite</type>
+            <definition>A description of the resource. The format is open, but the preferred format is a single term of some detail so that a pair can be formed with the sub-property. Text formats can be free-text OR terms from the CASRAI Publications resource type list.</definition>
 
             <property>
-                <name>LastName</name>
-                <definition>The authors last name (Doe).</definition>
+                <name>resourceTypeGeneral</name>
                 <type>string</type>
+                <value>[Audiovisual, Collection, DataPaper, Dataset, Event, Image, InteractiveResource, Model, PhysicalObject, Service, Software, Sound, Text, Workflow, Other]</value>
+                <definition>The general type of a resource.</definition>
             </property>
             <property>
-                <name>Affiliation</name>
-                <definition>Affiliation of the author [Institute, City, Country]</definition>
+                <name>resourceType</name>
                 <type>string</type>
+                <definition>Value of the resourceType</definition>
             </property>
-            <property>
-                <name>Id</name>
-                <definition>Any Id that is capable of identifying the author e.g. ORCID</definition>
-                <type>string</type>
-            </property>
+        </section>
+
+        <!-- #6 Subject  -->
+        <!-- can be used to provide keywords describing the dataset -->
+        <section>
+            <name>subjects</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>subject #</name>
+                <type>DataCite</type>
+                <definition>Subject, keyword, classification code, or key phrase describing the resource.</definition>
+
+                <property>
+                    <name>subject</name>
+                    <type>string</type>
+                    <definition>Value of the subject.</definition>
+                </property>
+                <property>
+                    <name>subjectScheme</name>
+                    <type>string</type>
+                    <definition>The name of the subject scheme or classification code or authority if one is used.</definition>
+                </property>
+                <property>
+                    <name>schemeURI</name>
+                    <type>url</type>
+                    <definition>The URI of the subject identifier scheme.</definition>
+                </property>
+                <property>
+                    <name>valueURI</name>
+                    <type>url</type>
+                    <definition>The URI of the subject term.</definition>
+                </property>
+            </section>
+        </section>
+
+        <!-- #7 Contributor -->
+        <section>
+            <name>contributrors</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>contributor #</name>
+                <type>DataCite</type>
+                <definition>The institution or person responsible for collecting, managing, distributing, or otherwise contributing to the development of the resource.To supply multiple contributors, repeat this property.For software, if there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "hostingInstitution" for the code repository.</definition>
+
+                <property>
+                    <name>contributerType</name>
+                    <type>string</type>
+                    <value>[ContactPerson, DataCollector, DataCurator, DataManager, Distributor, Editor, HostingInstitution, Producer, ProjectLeader, ProjectManager, ProjectMember, RegistrationAgency, RegistrationAuthority, RelatedPerson, Researcher, ResearchGroup, RightsHolder, Sponsor, Supervisor, WorkPackageLeader, Other]</value>
+                    <definition>The type of contributor of the resource.</definition>
+                </property>
+                <property>
+                    <name>contributorName</name>
+                    <type>string</type>
+                    <definition>The full name of the contributor.</definition>
+                </property>
+                <property>
+                    <name>nameType</name>
+                    <type>string</type>
+                    <value>[Organizational, Personal (default)]</value>
+                    <definition>The type of name</definition>
+                </property>
+                <property>
+                    <name>givenName</name>
+                    <type>string</type>
+                    <definition>The personal or first name of the contributor.</definition>
+                </property>
+                <property>
+                    <name>familyName</name>
+                    <type>string</type>
+                    <definition>The surname or last name of the contributor.</definition>
+                </property>
+
+                <section>
+                    <name>namedIdentifier #</name>
+                    <type>DataCite</type>
+                    <definition>Uniquely identifies an individual or legal entity, according to various schemes.</definition>
+
+                    <property>
+                        <name>namedIdentifier</name>
+                        <type>string</type>
+                        <definition>Value of the namedIdentifier.</definition>
+                    </property>
+                    <property>
+                        <name>nameIdentifierScheme</name>
+                        <type>string</type>
+                        <definition>The name of the name identifier scheme. Examples: ORCID, ISNI, ROR, GRID</definition>
+                    </property>
+                    <property>
+                        <name>schemeURI</name>
+                        <type>url</type>
+                        <definition>The URI of the name identifier scheme.</definition>
+                    </property>
+                </section>
+
+                <section>
+                    <name>affiliation #</name>
+                    <type>DataCite</type>
+                    <definition>The organizational or institutional affiliation of the contributor.</definition>
+
+                    <property>
+                        <name>affiliation</name>
+                        <type>string</type>
+                        <definition>Value of the affiliation.</definition>
+                    </property>
+                    <property>
+                        <name>affiliationIdentifier</name>
+                        <type>string</type>
+                        <definition>Uniquely identifies the organizational affiliation of the contributor.</definition>
+                    </property>
+                    <property>
+                        <name>affiliationIdentifierScheme</name>
+                        <type>string</type>
+                        <definition>Name of the affiliation identifier schema. Examples: ROR, GRID</definition>
+                    </property>
+                    <property>
+                        <name>schemeURI</name>
+                        <type>url</type>
+                        <definition>URI of the affiliation identifier schema.</definition>
+                    </property>
+                </section>
+            </section>
+        </section>
+
+        <!-- #8 date -->
+        <section>
+            <name>dates</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>date #</name>
+                <type>DataCite</type>
+                <definition>Different dates relevant to the work.</definition>
+
+                <property>
+                    <name>date</name>
+                    <type>string</type>
+                    <definition>Value of date. YYYY,YYYY-MM-DD, YYYY-MM-DDThh:mm:ssTZD or any other format or level of granularity described in W3CDTF24. Use RKMS-ISO860125standard for depicting date ranges.Example: 2004-03-02/2005-06-02.Years before 0000 must be prefixed with a -sign,e.g. -0054 to indicate 55 BC.</definition>
+                </property>
+                <property>
+                    <name>dateType</name>
+                    <type>string</type>
+                    <value>[Accepted, Available, Copyrighted, Collected, Created, Issued, Submitted, Updated, Valid, Withdrawn, Other]</value>
+                    <definition>The type of date. If Date is used, dateType is mandatory.</definition>
+                </property>
+                <property>
+                    <name>dateInformation</name>
+                    <type>string</type>
+                    <definition>Specific information about the date, if appropriate.</definition>
+                </property>
+            </section>
+        </section>
+
+        <!-- #9 Language -->
+        <property>
+            <name>language</name>
+            <type>string</type>
+            <definition>The primary language of the resource. Allowed values are taken from IETF BCP 47, ISO 639-1 language codes.Examples: en, de, fr</definition>
+        </property>
+
+        <!-- #11 alternateIdentifier  -->
+        <section>
+            <name>alternateIdentifiers</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>alternateIdentifier #</name>
+                <type>DataCite</type>
+                <definition>An identifier or identifiers other than the primary Identifier applied to the resource being registered. This may be any alphanumeric string which is unique within its domain of issue. May be used for local identifiers. AlternateIdentifier should be used for another identifier of the same instance (same location, same file).</definition>
+
+                <property>
+                    <name>alternateIdentifier</name>
+                    <type>string</type>
+                    <definition>Value of alternateIdentifier</definition>
+                </property>
+                <property>
+                    <name>alternateIdentifierType</name>
+                    <type>string</type>
+                    <definition>The type of the AlternateIdentifier. If alternateIdentifier is used, alternateIdentifierType is mandatory.</definition>
+                </property>
+            </section>
+        </section>
+
+        <!-- #12 relatedIdentifier -->
+        <section>
+            <name>relatedIdentifiers</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>relatedIdentifier #</name>
+                <type>DataCite</type>
+                <definition>Identifiers of related resources. These must be globally unique identifiers.</definition>
+
+                <property>
+                    <name>relatedIdentifier</name>
+                    <type>string</type>
+                    <definition>Value of relatedIdentifier</definition>
+                </property>
+                <property>
+                    <name>relatedIdentifierType</name>
+                    <type>string</type>
+                    <value>[ARK, arXiv, bibcode, DOI, EAN13, EISSN, Handle, IGSN, ISBN, ISSN, ISTC, LISSN, LSID, PMID, PURL, UPC, URL, URN, w3id]</value>
+                    <definition>The type of the RelatedIdentifier</definition>
+                </property>
+                <property>
+                    <name>relationType</name>
+                    <type>string</type>
+                    <value>[IsCitedBy, Cites, IsSupplementTo, IsSupplementedBy, IsContinuedBy, Continues, IsDescribedBy, Describes, HasMetadata, IsMetadataFor, HasVersion, IsVersionOf, IsNewVersionOf, IsPreviousVersionOf, IsPartOf, HasPart, IsReferencedBy, References, IsDocumentedBy, Documents, IsCompiledBy, Compiles, IsVariantFormOf, IsOriginalFormOf, IsIdenticalTo, IsReviewedBy, Reviews, IsDerivedFrom, IsSourceOf, IsRequiredBy, Requires, IsObsoletedBy, Obsoletes]</value>
+                    <definition>Description of the relationship of the resource being registered (A) and the related resource (B).</definition>
+                </property>
+                <property>
+                    <name>relatedMetadataScheme</name>
+                    <type>string</type>
+                    <definition>The name of the scheme. Use only with this relation pair: (HasMetadata/IsMetadataFor)</definition>
+                </property>
+                <property>
+                    <name>schemeURI</name>
+                    <type>url</type>
+                    <definition>The URI of the relatedMetadataScheme. Use only with this relation pair: (HasMetadata/IsMetadataFor)</definition>
+                </property>
+                <property>
+                    <name>schemeType</name>
+                    <type>string</type>
+                    <definition>The type of the relatedMetadataScheme, linked with the schemeURI. Use only with this relation pair: (HasMetadata/IsMetadataFor)</definition>
+                </property>
+                <property>
+                    <name>resourceTypeGeneral</name>
+                    <type>string</type>
+                    <definition>The general type of the related resource.</definition>
+                </property>
+            </section>
+        </section>
+
+        <!-- #13 size -->
+        <section>
+            <name>sizes</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>size #</name>
+                <type>DataCite</type>
+                <definition>Size (e.g. bytes, pages, inches, etc.) or duration (extent), e.g. hours, minutes, days, etc., of a resource.</definition>
+
+                <property>
+                    <name>size</name>
+                    <type>string</type>
+                    <definition>Value of size.</definition>
+                </property>
+            </section>
+        </section>
+
+        <!-- #14 format -->
+        <section>
+            <name>formats</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>format #</name>
+                <type>DataCite</type>
+                <definition>Technical format of the resource.</definition>
+
+                <property>
+                    <name>format</name>
+                    <type>string</type>
+                    <definition>Value of format.</definition>
+                </property>
+            </section>
+        </section>
+
+        <!-- #15 version -->
+        <property>
+            <name>version</name>
+            <type>string</type>
+            <definition>The version number of the resource. Suggested practice: track major_version.minor_version. Register a new identifier for a major version change.</definition>
+        </property>
+
+        <!-- #16 Rights -->
+        <section>
+            <name>rightsList</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>rights #</name>
+                <type>DataCite</type>
+                <definition>Any rights information for this resource. The property may be repeated to record complex rights characteristics.</definition>
+
+                <property>
+                    <name>rightsURI</name>
+                    <type>url</type>
+                    <definition>The URI of the license.</definition>
+                </property>
+                <property>
+                    <name>rightsIdentifier</name>
+                    <type>string</type>
+                    <definition>A short, standardized version of the license name.</definition>
+                </property>
+                <property>
+                    <name>rightsIdentifierScheme</name>
+                    <type>string</type>
+                    <definition>The name of the scheme.</definition>
+                </property>
+                <property>
+                    <name>schemeURI</name>
+                    <type>url</type>
+                    <definition>The URI of the rightsIdentifierScheme.</definition>
+                </property>
+            </section>
+        </section>
+
+        <!-- #17 description -->
+        <section>
+            <name>descriptions</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>description #</name>
+                <type>DataCite</type>
+                <definition>All additional information that does not fit in any of the other categories. May be used for technical information.</definition>
+
+                <property>
+                    <name>description</name>
+                    <type>string</type>
+                    <value>Value of description.</value>
+                </property>
+                <property>
+                    <name>descriptionType</name>
+                    <type>string</type>
+                    <value>[Abstract, Methods, Series, Information, TableOfContents ,TechnicalInfo, Other]</value>
+                    <definition>The type of the Description. If Description is used, descriptionType is mandatory.</definition>
+                </property>
+            </section>
+        </section>
+
+        <!-- #18 geolocation -->
+        <section>
+            <name>geoLocations</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>geoLocation #</name>
+                <type>DataCite</type>
+                <definition>Spatial region or named place where the data was gathered or about which the data is focused.</definition>
+
+                <property>
+                    <name>geoLocationPlace</name>
+                    <type>string</type>
+                    <definition>Description of a geographic location</definition>
+                </property>
+
+                <section>
+                    <name>geoLocationPoint</name>
+                    <type>DataCite</type>
+                    <definition>A point location in space.</definition>
+
+                    <property>
+                        <name>pointLongitude</name>
+                        <type>float</type>
+                        <definition>Longitudinal dimension of point.</definition>
+                    </property>
+                    <property>
+                        <name>pointLatitude</name>
+                        <type>float</type>
+                        <definition>Latitudinal dimension of point.</definition>
+                    </property>
+                </section>
+                <section>
+                    <name>geoLocationBox</name>
+                    <type>DataCite</type>
+                    <definition>The spatial limits of a box. A box is defined by two geographic points. Left low corner and right upper corner. Each point is defined by its longitude and latitude.</definition>
+
+                    <property>
+                        <name>westBoundLongitude</name>
+                        <type>float</type>
+                        <definition>Western longitudinal dimension of box.</definition>
+                    </property>
+                    <property>
+                        <name>eastBoundLongitude</name>
+                        <type>float</type>
+                        <definition>Eastern longitudinal dimension of box.</definition>
+                    </property>
+                    <property>
+                        <name>southBoundLatitude</name>
+                        <type>float</type>
+                        <definition>Southern latitudinal dimension of box.</definition>
+                    </property>
+                    <property>
+                        <name>northBoundLatitude</name>
+                        <type>float</type>
+                        <definition>Northern latitudinal dimension of box.</definition>
+                    </property>
+                </section>
+                <section>
+                    <name>geoLocationPolygon</name>
+                    <type>DataCite</type>
+                    <definition>A drawn polygon area, defined by a set of points and lines connecting the points in a closed chain.</definition>
+
+                    <section>
+                        <name>polygonPoint #</name>
+                        <type>DataCite</type>
+                        <definition>A point location in a polygon. If geoLocationPolygon is used, polygonPoint must be used as well. There must be at least 4 non-aligned points to make a closed curve, with the last point described the same as the first point.</definition>
+
+                        <property>
+                            <name>pointLatitude</name>
+                            <type>float</type>
+                            <definition>Longitudinal dimension of point.</definition>
+                        </property>
+                        <property>
+                            <name>pointLongitude</name>
+                            <type>float</type>
+                            <definition>Latitudinal dimension of point.</definition>
+                        </property>
+                    </section>
+                </section>
+            </section>
+        </section>
+
+        <!-- #19 fundingReference -->
+        <section>
+            <name>fundingReferences</name>
+            <type>DataCite</type>
+
+            <section>
+                <name>fundingReference #</name>
+                <type>DataCite</type>
+                <definition>Information about financial support (funding) for the resource being registered.</definition>
+
+                <property>
+                    <name>funderName</name>
+                    <type>string</type>
+                    <definition>Name of the funding provider.</definition>
+                </property>
+                <property>
+                    <name>funderIdentifier</name>
+                    <type>string</type>
+                    <definition>Uniquely identifies a funding entity, according to various types.</definition>
+                </property>
+                <property>
+                    <name>funderIdentifierType</name>
+                    <type>string</type>
+                    <value>[Crossref Funder ID, GRID, ISNI, ROR, Other]</value>
+                    <definition>The type of the funderIdentifier.</definition>
+                </property>
+                <property>
+                    <name>schemeURI</name>
+                    <type>url</type>
+                    <definition>The URI of the funder identifier schema.</definition>
+                </property>
+                <property>
+                    <name>awardNumber</name>
+                    <type>string</type>
+                    <definition>The code assigned by the funder to a sponsored award (grant).</definition>
+                </property>
+                <property>
+                    <name>awardURI</name>
+                    <type>url</type>
+                    <definition>The URI leading to a page provided by the funder for more information about the award (grant).</definition>
+                </property>
+                <property>
+                    <name>awardTitle</name>
+                    <type>string</type>
+                    <definition>The human readable title or name of the award (grant).</definition>
+                </property>
+            </section>
         </section>
 
     </section>
 
+    <section>
+        <name>DataCiteComplement</name>
+        <type>DataReference</type>
+        <definition>Additional sections complementing the Datacite scheme. The information contained in this section is not supported by the DataCite scheme.</definition>
+
+        <section>
+            <name>version</name>
+            <type>DataCiteComplement</type>
+            <definition>The implemented datacite schema version</definition>
+
+            <property>
+                <name>version</name>
+                <value>4.3</value>
+                <type>string</type>
+                <reference>https://schema.datacite.org/meta/kernel-4.3/</reference>
+            </property>
+        </section>
+
+        <section>
+            <name>References</name>
+            <type>DataCiteComplement</type>
+
+            <section>
+                <name>Reference #</name>
+                <type>DataCiteComplement</type>
+                <definition>A publication the published dataset is referencing.</definition>
+
+                <property>
+                    <name>DOI</name>
+                    <type>string</type>
+                    <definition>DOI to the referenced publication</definition>
+                </property>
+                <property>
+                    <name>RefType</name>
+                    <type>string</type>
+                    <definition>refType might be: IsCitedBy, IsSupplementTo, IsReferencedBy, IsPartOf for further valid types see https://schema.datacite.org/meta/kernel-4</definition>
+                </property>
+                <property>
+                    <name>PublictionCitation</name>
+                    <type>string</type>
+                    <definition>Full citation of the reference publication</definition>
+                </property>
+            </section>
+        </section>
+
+    </section>
 </odML>

--- a/v1.1/datareference/datacite.xml
+++ b/v1.1/datareference/datacite.xml
@@ -13,7 +13,7 @@
         <!-- #1 identifier -->
         <section>
             <name>identifier</name>
-            <type>DataCite</type>
+            <type>DataCite/identifier</type>
             <definition>The Identifier is a unique string that identifies a resource.  For software, determine whether the identifier is for a specific version of a piece of software, (per the Force11 Software Citation Principles11), or for all versions.</definition>
 
             <property>
@@ -32,11 +32,11 @@
         <!-- #2 creators -->
         <section>
             <name>creators</name>
-            <type>DataCite</type>
+            <type>DataCite/creator</type>
 
             <section>
                 <name>creator #</name>
-                <type>DataCite</type>
+                <type>DataCite/creator</type>
                 <definition>The main researchers involved in producing the data, or the authors of the publication, in priority order. To supply multiple creators, repeat this property.</definition>
 
                 <property>
@@ -63,7 +63,7 @@
 
                 <section>
                     <name>namedIdentifier #</name>
-                    <type>DataCite</type>
+                    <type>DataCite/creator</type>
                     <definition>Uniquely identifies an individual or legal entity, according to various schemes.</definition>
 
                     <property>
@@ -85,7 +85,7 @@
 
                 <section>
                     <name>affiliation #</name>
-                    <type>DataCite</type>
+                    <type>DataCite/creator</type>
                     <definition>The organizational or institutional affiliation of the creator.</definition>
 
                     <property>
@@ -115,11 +115,11 @@
         <!-- #3 Title -->
         <section>
             <name>titles</name>
-            <type>DataCite</type>
+            <type>DataCite/title</type>
 
             <section>
                 <name>title #</name>
-                <type>DataCite</type>
+                <type>DataCite/title</type>
                 <definition>A name or title by which a resource is known. May be the title of a dataset or the name of a piece of software.</definition>
 
                 <property>
@@ -153,7 +153,7 @@
         <!-- #10 ResourceType -->
         <section>
             <name>resourceType</name>
-            <type>DataCite</type>
+            <type>DataCite/resourceType</type>
             <definition>A description of the resource. The format is open, but the preferred format is a single term of some detail so that a pair can be formed with the sub-property. Text formats can be free-text OR terms from the CASRAI Publications resource type list.</definition>
 
             <property>
@@ -173,11 +173,11 @@
         <!-- can be used to provide keywords describing the dataset -->
         <section>
             <name>subjects</name>
-            <type>DataCite</type>
+            <type>DataCite/subject</type>
 
             <section>
                 <name>subject #</name>
-                <type>DataCite</type>
+                <type>DataCite/subject</type>
                 <definition>Subject, keyword, classification code, or key phrase describing the resource.</definition>
 
                 <property>
@@ -206,11 +206,11 @@
         <!-- #7 Contributor -->
         <section>
             <name>contributors</name>
-            <type>DataCite</type>
+            <type>DataCite/contributor</type>
 
             <section>
                 <name>contributor #</name>
-                <type>DataCite</type>
+                <type>DataCite/contributor</type>
                 <definition>The institution or person responsible for collecting, managing, distributing, or otherwise contributing to the development of the resource.To supply multiple contributors, repeat this property.For software, if there is an alternate entity that "holds, archives, publishes, prints, distributes, releases, issues, or produces" the code, use the contributorType "hostingInstitution" for the code repository.</definition>
 
                 <property>
@@ -243,7 +243,7 @@
 
                 <section>
                     <name>namedIdentifier #</name>
-                    <type>DataCite</type>
+                    <type>DataCite/contributor</type>
                     <definition>Uniquely identifies an individual or legal entity, according to various schemes.</definition>
 
                     <property>
@@ -265,7 +265,7 @@
 
                 <section>
                     <name>affiliation #</name>
-                    <type>DataCite</type>
+                    <type>DataCite/contributor</type>
                     <definition>The organizational or institutional affiliation of the contributor.</definition>
 
                     <property>
@@ -295,11 +295,11 @@
         <!-- #8 date -->
         <section>
             <name>dates</name>
-            <type>DataCite</type>
+            <type>DataCite/date</type>
 
             <section>
                 <name>date #</name>
-                <type>DataCite</type>
+                <type>DataCite/date</type>
                 <definition>Different dates relevant to the work.</definition>
 
                 <property>
@@ -331,11 +331,11 @@
         <!-- #11 alternateIdentifier  -->
         <section>
             <name>alternateIdentifiers</name>
-            <type>DataCite</type>
+            <type>DataCite/alternateIdentifier</type>
 
             <section>
                 <name>alternateIdentifier #</name>
-                <type>DataCite</type>
+                <type>DataCite/alternateIdentifier</type>
                 <definition>An identifier or identifiers other than the primary Identifier applied to the resource being registered. This may be any alphanumeric string which is unique within its domain of issue. May be used for local identifiers. AlternateIdentifier should be used for another identifier of the same instance (same location, same file).</definition>
 
                 <property>
@@ -354,11 +354,11 @@
         <!-- #12 relatedIdentifier -->
         <section>
             <name>relatedIdentifiers</name>
-            <type>DataCite</type>
+            <type>DataCite/relatedIdentifier</type>
 
             <section>
                 <name>relatedIdentifier #</name>
-                <type>DataCite</type>
+                <type>DataCite/relatedIdentifier</type>
                 <definition>Identifiers of related resources. These must be globally unique identifiers.</definition>
 
                 <property>
@@ -404,11 +404,11 @@
         <!-- #13 size -->
         <section>
             <name>sizes</name>
-            <type>DataCite</type>
+            <type>DataCite/size</type>
 
             <section>
                 <name>size #</name>
-                <type>DataCite</type>
+                <type>DataCite/size</type>
                 <definition>Size (e.g. bytes, pages, inches, etc.) or duration (extent), e.g. hours, minutes, days, etc., of a resource.</definition>
 
                 <property>
@@ -422,11 +422,11 @@
         <!-- #14 format -->
         <section>
             <name>formats</name>
-            <type>DataCite</type>
+            <type>DataCite/format</type>
 
             <section>
                 <name>format #</name>
-                <type>DataCite</type>
+                <type>DataCite/format</type>
                 <definition>Technical format of the resource.</definition>
 
                 <property>
@@ -447,11 +447,11 @@
         <!-- #16 Rights -->
         <section>
             <name>rightsList</name>
-            <type>DataCite</type>
+            <type>DataCite/rights</type>
 
             <section>
                 <name>rights #</name>
-                <type>DataCite</type>
+                <type>DataCite/rights</type>
                 <definition>Any rights information for this resource. The property may be repeated to record complex rights characteristics.</definition>
 
                 <property>
@@ -480,11 +480,11 @@
         <!-- #17 description -->
         <section>
             <name>descriptions</name>
-            <type>DataCite</type>
+            <type>DataCite/description</type>
 
             <section>
                 <name>description #</name>
-                <type>DataCite</type>
+                <type>DataCite/description</type>
                 <definition>All additional information that does not fit in any of the other categories. May be used for technical information.</definition>
 
                 <property>
@@ -504,11 +504,11 @@
         <!-- #18 geolocation -->
         <section>
             <name>geoLocations</name>
-            <type>DataCite</type>
+            <type>DataCite/geoLocation</type>
 
             <section>
                 <name>geoLocation #</name>
-                <type>DataCite</type>
+                <type>DataCite/geoLocation</type>
                 <definition>Spatial region or named place where the data was gathered or about which the data is focused.</definition>
 
                 <property>
@@ -519,7 +519,7 @@
 
                 <section>
                     <name>geoLocationPoint</name>
-                    <type>DataCite</type>
+                    <type>DataCite/geoLocation</type>
                     <definition>A point location in space.</definition>
 
                     <property>
@@ -535,7 +535,7 @@
                 </section>
                 <section>
                     <name>geoLocationBox</name>
-                    <type>DataCite</type>
+                    <type>DataCite/geoLocation</type>
                     <definition>The spatial limits of a box. A box is defined by two geographic points. Left low corner and right upper corner. Each point is defined by its longitude and latitude.</definition>
 
                     <property>
@@ -561,7 +561,7 @@
                 </section>
                 <section>
                     <name>geoLocationPolygon</name>
-                    <type>DataCite</type>
+                    <type>DataCite/geoLocation</type>
                     <definition>A drawn polygon area, defined by a set of points and lines connecting the points in a closed chain.</definition>
 
                     <section>
@@ -587,11 +587,11 @@
         <!-- #19 fundingReference -->
         <section>
             <name>fundingReferences</name>
-            <type>DataCite</type>
+            <type>DataCite/fundingReference</type>
 
             <section>
                 <name>fundingReference #</name>
-                <type>DataCite</type>
+                <type>DataCite/fundingReference</type>
                 <definition>Information about financial support (funding) for the resource being registered.</definition>
 
                 <property>
@@ -642,7 +642,7 @@
 
         <section>
             <name>version</name>
-            <type>DataCiteComplement</type>
+            <type>DataCiteComplement/version</type>
             <definition>The implemented datacite schema version</definition>
 
             <property>
@@ -654,12 +654,12 @@
         </section>
 
         <section>
-            <name>References</name>
-            <type>DataCiteComplement</type>
+            <name>references</name>
+            <type>DataCiteComplement/reference</type>
 
             <section>
-                <name>Reference #</name>
-                <type>DataCiteComplement</type>
+                <name>reference #</name>
+                <type>DataCiteComplement/reference</type>
                 <definition>A publication the published dataset is referencing.</definition>
 
                 <property>
@@ -668,12 +668,12 @@
                     <definition>DOI to the referenced publication</definition>
                 </property>
                 <property>
-                    <name>RefType</name>
+                    <name>refType</name>
                     <type>string</type>
                     <definition>refType might be: IsCitedBy, IsSupplementTo, IsReferencedBy, IsPartOf for further valid types see https://schema.datacite.org/meta/kernel-4</definition>
                 </property>
                 <property>
-                    <name>PublicationCitation</name>
+                    <name>publicationCitation</name>
                     <type>string</type>
                     <definition>Full citation of the reference publication</definition>
                 </property>

--- a/v1.1/datareference/datacite.xml
+++ b/v1.1/datareference/datacite.xml
@@ -331,11 +331,11 @@
         <!-- #11 alternateIdentifier  -->
         <section>
             <name>alternateIdentifiers</name>
-            <type>datacite/alternateIdentifiers</type>
+            <type>datacite/alternate_identifiers</type>
 
             <section>
                 <name>alternateIdentifier #</name>
-                <type>datacite/alternateIdentifiers/alternateIdentifier</type>
+                <type>datacite/alternate_identifiers/alternate_identifier</type>
                 <definition>An identifier or identifiers other than the primary Identifier applied to the resource being registered. This may be any alphanumeric string which is unique within its domain of issue. May be used for local identifiers. AlternateIdentifier should be used for another identifier of the same instance (same location, same file).</definition>
 
                 <property>

--- a/v1.1/datareference/datadoi.xml
+++ b/v1.1/datareference/datadoi.xml
@@ -13,7 +13,7 @@
           can be added via the reference description section              -->
     <!-- *********************************************************        -->
     <section>
-        <type>DataReference</type>
+        <type>data_reference</type>
         <name>DataDOI</name>
         <definition>A published dataset referenced by a DOI. The referenced dataset will contain either the odML file itself or the data the odML is annotating.
         </definition>

--- a/v1.1/datareference/datauri.xml
+++ b/v1.1/datareference/datauri.xml
@@ -13,7 +13,7 @@
           can be added via the reference description section              -->
     <!-- *********************************************************        -->
     <section>
-        <type>DataReference</type>
+        <type>data_reference</type>
         <name>DataURI</name>
         <definition>A published dataset referenced by a URI. The referenced dataset will contain either the odML file itself or the data the odML is annotating.
         </definition>

--- a/v1.1/datareference/dataurl.xml
+++ b/v1.1/datareference/dataurl.xml
@@ -13,7 +13,7 @@
           can be added via the reference description section              -->
     <!-- *********************************************************        -->
     <section>
-        <type>DataReference</type>
+        <type>data_reference</type>
         <name>DataURL</name>
         <definition>A published dataset referenced by a URL. The referenced dataset will contain either the odML file itself or the data the odML is annotating.
         </definition>

--- a/v1.1/datareference/referencedescription.xml
+++ b/v1.1/datareference/referencedescription.xml
@@ -8,7 +8,7 @@
     <!--         Data reference description  section               -->
     <!-- ********************************************************* -->
     <section>
-        <type>DataReference</type>
+        <type>data_reference/description</type>
         <name>DataReferenceDescription</name>
         <definition>Description of a data reference. This Section is defined to be used as a subsection of the 'DataReference' type sections.</definition>
 

--- a/v1.1/terminologies.xml
+++ b/v1.1/terminologies.xml
@@ -3,6 +3,63 @@
 <odML version="1.1">
 
   <section>
+    <type>analysis</type>
+    <name>Analysis</name>
+    <definition>Sections of the Analysis type can be used to describe analyses.</definition>
+    <include>https://terminologies.g-node.org/v1.1/analysis/analysis.xml</include>
+  </section>
+
+  <section>
+    <type>analysis/power_spectrum</type>
+    <name>PowerSpectrum</name>
+    <definition>Properties of this section define the way a power spectrum was calculated.</definition>
+    <include>https://terminologies.g-node.org/v1.1/analysis/power_spectrum.xml</include>
+  </section>
+
+  <section>
+    <type>analysis/psth</type>
+    <name>PSTH</name>
+    <definition>An Analysis-type section to describe a PSTH.</definition>
+    <include>https://terminologies.g-node.org/v1.1/analysis/psth.xml</include>
+  </section>
+
+  <section>
+    <type>blackrock</type>
+    <name>Blackrock</name>
+    <definition>Information on the Cerebus^TM data acquisition system</definition>
+    <include>https://terminologies.g-node.org/v1.1/blackrock/blackrock.xml</include>
+  </section>
+
+  <section>
+    <type>carmen_mini</type>
+    <name>CarmenMini</name>
+    <definition>This is a convenience section that lists the terms of the CARMEN MINI (Gibson et al. Nature Precedings,
+      2009 Version 0.6) and maps them to the odml "standard" terminologies.
+    </definition>
+    <include>https://terminologies.g-node.org/v1.1/carmenMini/carmen_mini.xml</include>
+  </section>
+
+  <section>
+    <type>cell</type>
+    <name>Cell</name>
+    <definition>Specification of the recorded cell. A cell definition should be a subsection of the
+      <a href="../subject/subject.xml">Subject</a>
+      section.
+    </definition>
+    <include>https://terminologies.g-node.org/v1.1/cell/cell.xml</include>
+  </section>
+
+  <section>
+    <type>dataset</type>
+    <name>Dataset</name>
+    <definition>Names (URLs) and times of recorded data files. Datasets are obtained during a Recording and may belong
+      to different Experiments. Related sections that can be used as subsections, parent sections, or siblings are
+      Stimulus, HardwareSettings, and Experiment.
+    </definition>
+    <include>https://terminologies.g-node.org/v1.1/dataset/dataset.xml</include>
+  </section>
+
+  <section>
     <type>DataReference</type>
     <name>DataCite</name>
     <definition>A published dataset referenced by a DOI and registered with DataCite. The referenced dataset will contain either the odML file itself or the data the odML is annotating.</definition>
@@ -35,54 +92,6 @@
     <name>DataReferenceDescription</name>
     <definition>Description of a data reference. This Section is defined to be used as a subsection of the 'DataReference' type sections.</definition>
     <include>https://terminologies.g-node.org/v1.1/datareference/referencedescription.xml</include>
-  </section>
-
-  <section>
-    <type>analysis</type>
-    <name>Analysis</name>
-    <definition>Sections of the Analysis type can be used to describe analyses.</definition>
-    <include>https://terminologies.g-node.org/v1.1/analysis/analysis.xml</include>
-  </section>
-
-  <section>
-    <type>analysis/psth</type>
-    <name>PSTH</name>
-    <definition>An Analysis-type section to describe a PSTH.</definition>
-    <include>https://terminologies.g-node.org/v1.1/analysis/psth.xml</include>
-  </section>
-
-  <section>
-    <type>analysis/power_spectrum</type>
-    <name>PowerSpectrum</name>
-    <definition>Properties of this section define the way a power spectrum was calculated.</definition>
-    <include>https://terminologies.g-node.org/v1.1/analysis/power_spectrum.xml</include>
-  </section>
-
-  <section>
-    <type>cell</type>
-    <name>Cell</name>
-    <definition>Specification of the recorded cell. A cell definition should be a subsection of the
-      <a href="../subject/subject.xml">Subject</a>
-      section.
-    </definition>
-    <include>https://terminologies.g-node.org/v1.1/cell/cell.xml</include>
-  </section>
-
-  <section>
-    <type>dataset</type>
-    <name>Dataset</name>
-    <definition>Names (URLs) and times of recorded data files. Datasets are obtained during a Recording and may belong
-      to different Experiments. Related sections that can be used as subsections, parent sections, or siblings are
-      Stimulus, HardwareSettings, and Experiment.
-    </definition>
-    <include>https://terminologies.g-node.org/v1.1/dataset/dataset.xml</include>
-  </section>
-
-  <section>
-    <type>blackrock</type>
-    <name>Blackrock</name>
-    <definition>Information on the Cerebus^TM data acquisition system</definition>
-    <include>https://terminologies.g-node.org/v1.1/blackrock/blackrock.xml</include>
   </section>
 
   <section>
@@ -283,17 +292,17 @@
   </section>
 
   <section>
+    <type>license</type>
+    <name>License</name>
+    <definition>This section contains keywords to a data or software license.</definition>
+    <include>https://terminologies.g-node.org/v1.1/license/license.xml</include>
+  </section>
+
+  <section>
     <type>model/lif</type>
     <name>Leaky integrate and fire</name>
     <definition>Section to describe a leaky integrate and fire neuron model.</definition>
     <include>https://terminologies.g-node.org/v1.1/model/lif.xml</include>
-  </section>
-
-  <section>
-    <type>model/pif</type>
-    <name>perfect integrate and fire</name>
-    <definition>Section to describe a perfect integrate and fire model.</definition>
-    <include>https://terminologies.g-node.org/v1.1/model/pif.xml</include>
   </section>
 
   <section>
@@ -304,31 +313,17 @@
   </section>
 
   <section>
+    <type>model/pif</type>
+    <name>perfect integrate and fire</name>
+    <definition>Section to describe a perfect integrate and fire model.</definition>
+    <include>https://terminologies.g-node.org/v1.1/model/pif.xml</include>
+  </section>
+
+  <section>
     <type>model/single_compartment</type>
     <name>One compartment model</name>
     <definition>Section to describe a biophysical model that consists of a single compartment.</definition>
     <include>https://terminologies.g-node.org/v1.1/model/single_compartment.xml</include>
-  </section>
-
-  <section>
-    <type>license</type>
-    <name>License</name>
-    <definition>This section contains keywords to a data or software license.</definition>
-    <include>https://terminologies.g-node.org/v1.1/license/license.xml</include>
-  </section>
-
-  <section>
-    <type>questionnaire/questionnaire</type>
-    <name>Questionnaire</name>
-    <definition>Description of a questionnaire.</definition>
-    <include>https://terminologies.g-node.org/v1.1/questionnaire/questionnaire.xml</include>
-  </section>
-
-  <section>
-    <type>questionnaire/question</type>
-    <name>Question</name>
-    <definition>Description of a question if a questionnaire.</definition>
-    <include>https://terminologies.g-node.org/v1.1/questionnaire/question.xml</include>
   </section>
 
   <section>
@@ -357,6 +352,20 @@
     <name>protocol</name>
     <definition>Information about the experimental protocol.</definition>
     <include>https://terminologies.g-node.org/v1.1/protocol/protocol.xml</include>
+  </section>
+
+  <section>
+    <type>questionnaire/question</type>
+    <name>Question</name>
+    <definition>Description of a question if a questionnaire.</definition>
+    <include>https://terminologies.g-node.org/v1.1/questionnaire/question.xml</include>
+  </section>
+
+  <section>
+    <type>questionnaire/questionnaire</type>
+    <name>Questionnaire</name>
+    <definition>Description of a questionnaire.</definition>
+    <include>https://terminologies.g-node.org/v1.1/questionnaire/questionnaire.xml</include>
   </section>
 
   <section>
@@ -416,18 +425,18 @@
   </section>
 
   <section>
+    <type>stimulus/movie</type>
+    <name>Movie</name>
+    <definition>Properties to describe a movie (or image sequence) stimulus.</definition>
+    <include>https://terminologies.g-node.org/v1.1/stimulus/movie.xml</include>
+  </section>
+
+  <section>
     <type>stimulus/pulse</type>
     <name>Pulse</name>
     <definition>Properties to describe a simple pulse stimulus that starts from and returns to a certain baseline.
     </definition>
     <include>https://terminologies.g-node.org/v1.1/stimulus/pulse.xml</include>
-  </section>
-
-  <section>
-    <type>stimulus/movie</type>
-    <name>Movie</name>
-    <definition>Properties to describe a movie (or image sequence) stimulus.</definition>
-    <include>https://terminologies.g-node.org/v1.1/stimulus/movie.xml</include>
   </section>
 
   <section>
@@ -482,15 +491,6 @@
       May contain the Cell and Preparation sections as subsections.
     </definition>
     <include>https://terminologies.g-node.org/v1.1/subject/subject.xml</include>
-  </section>
-
-  <section>
-    <type>carmen_mini</type>
-    <name>CarmenMini</name>
-    <definition>This is a convenience section that lists the terms of the CARMEN MINI (Gibson et al. Nature Precedings,
-      2009 Version 0.6) and maps them to the odml "standard" terminologies.
-    </definition>
-    <include>https://terminologies.g-node.org/v1.1/carmenMini/carmen_mini.xml</include>
   </section>
 
 </odML>

--- a/v1.1/terminologies.xml
+++ b/v1.1/terminologies.xml
@@ -60,35 +60,35 @@
   </section>
 
   <section>
-    <type>DataReference</type>
+    <type>data_reference</type>
     <name>DataCite</name>
     <definition>A published dataset referenced by a DOI and registered with DataCite. The referenced dataset will contain either the odML file itself or the data the odML is annotating.</definition>
     <include>https://terminologies.g-node.org/v1.1/datareference/datacite.xml</include>
   </section>
 
   <section>
-    <type>DataReference</type>
+    <type>data_reference</type>
     <name>DataDOI</name>
     <definition>A published dataset referenced by a DOI. The referenced dataset will contain either the odML file itself or the data the odML is annotating.</definition>
     <include>https://terminologies.g-node.org/v1.1/datareference/datadoi.xml</include>
   </section>
 
   <section>
-    <type>DataReference</type>
+    <type>data_reference</type>
     <name>DataURI</name>
     <definition>A published dataset referenced by a URI. The referenced dataset will contain either the odML file itself or the data the odML is annotating.</definition>
     <include>https://terminologies.g-node.org/v1.1/datareference/datauri.xml</include>
   </section>
 
   <section>
-    <type>DataReference</type>
+    <type>data_reference</type>
     <name>DataURL</name>
     <definition>A published dataset referenced by a URL. The referenced dataset will contain either the odML file itself or the data the odML is annotating.</definition>
     <include>https://terminologies.g-node.org/v1.1/datareference/dataurl.xml</include>
   </section>
 
   <section>
-    <type>DataReference</type>
+    <type>data_reference/description</type>
     <name>DataReferenceDescription</name>
     <definition>Description of a data reference. This Section is defined to be used as a subsection of the 'DataReference' type sections.</definition>
     <include>https://terminologies.g-node.org/v1.1/datareference/referencedescription.xml</include>
@@ -150,7 +150,7 @@
   </section>
 
   <section>
-    <type>experiment/pschophysics</type>
+    <type>experiment/psychophysics</type>
     <name>Psychophysics</name>
     <definition>Properties for describing an psychophysical experiment.</definition>
     <include>https://terminologies.g-node.org/v1.1/experiment/psychophysics.xml</include>


### PR DESCRIPTION
The datacite.xml is now fully compliant with the latest datacite schema version 4.3. Subsets for easy usage should be created over on the templates side.

The PR also contains further minor changes:
- switching the image on the index page to odMLTitle to keep templates and terminologies as similar as possible.
- adding sub-headings to make the link to the odML terminologies easier to find.
- re-ordering sections on the main terminologies page to an alphabetical order.
- changing section types to snake_case in all data_reference terminologies.
