### PR TITLE
Minor hyperlink fixes

### DIFF
--- a/v1.0/index.xml
+++ b/v1.0/index.xml
@@ -178,7 +178,7 @@
     <type>hardware/camera_objective</type>
     <name>CameraObjective</name>
     <definition>This section contains properties that describe a camera objective.</definition>
-    <include>https://terminologies.g-node.org/v1.0/hardware/attenuator.xml</include>
+    <include>https://terminologies.g-node.org/v1.0/hardware/camera_objective.xml</include>
   </section>
 
   <section>

--- a/v1.0/terminologies.xml
+++ b/v1.0/terminologies.xml
@@ -178,7 +178,7 @@
     <type>hardware/camera_objective</type>
     <name>CameraObjective</name>
     <definition>This section contains properties that describe a camera objective.</definition>
-    <include>http://portal.g-node.org/odml/terminologies/v1.0/hardware/attenuator.xml</include>
+    <include>http://portal.g-node.org/odml/terminologies/v1.0/hardware/camera_objective.xml</include>
   </section>
 
   <section>

--- a/v1.1/terminologies.xml
+++ b/v1.1/terminologies.xml
@@ -223,7 +223,7 @@
     <type>hardware/camera_objective</type>
     <name>CameraObjective</name>
     <definition>This section contains properties that describe a camera objective.</definition>
-    <include>https://terminologies.g-node.org/v1.1/hardware/attenuator.xml</include>
+    <include>https://terminologies.g-node.org/v1.1/hardware/camera_objective.xml</include>
   </section>
 
   <section>


### PR DESCRIPTION
The main page in both v1.0 and v1.1 contains an erroneous hyperlink: camera_objective links to attenuator which will be rectified by this tiny PR.